### PR TITLE
libember_slim shared library

### DIFF
--- a/libember_slim/Source/api.h
+++ b/libember_slim/Source/api.h
@@ -36,9 +36,6 @@
 #endif
 
 #if defined LIBEMBER_DLL                // Define this if libember is compiled or used as a DLL/shared object
-#  ifdef LIBEMBER_HEADER_ONLY
-#    error "LIBEMBER_DLL may not be used in conjunction with LIBEMBER_HEADER_ONLY"
-#  endif
 #  ifdef LIBEMBER_DLL_EXPORTS           // Defined libember is being built (instead of using it)
 #    define LIBEMBER_API LIBEMBER_HELPER_DLL_EXPORT
 #  else

--- a/libember_slim/Source/api.h
+++ b/libember_slim/Source/api.h
@@ -1,0 +1,54 @@
+/*
+   LIBEMBER_SLIM_slim -- ANSI C implementation of the Ember+ Protocol
+   Copyright (C) 2012-2014  L-S-B Broadcast Technologies GmbH
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef __LIBEMBER_AP_H
+#define __LIBEMBER_AP_H
+
+/*
+ * Preprocessor definitions for generic symbol import/export support
+ * Adapted from http://gcc.gnu.org/wiki/Visibility
+ */
+
+#if defined _WIN32 || defined __CYGWIN__
+#  define LIBEMBER_HELPER_DLL_IMPORT __declspec(dllimport)
+#  define LIBEMBER_HELPER_DLL_EXPORT __declspec(dllexport)
+#  define LIBEMBER_HELPER_DLL_LOCAL
+#else
+#  define LIBEMBER_HELPER_DLL_IMPORT __attribute__ ((visibility ("default")))
+#  define LIBEMBER_HELPER_DLL_EXPORT __attribute__ ((visibility ("default")))
+#  define LIBEMBER_HELPER_DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+#endif
+
+#if defined LIBEMBER_DLL                // Define this if libember is compiled or used as a DLL/shared object
+#  ifdef LIBEMBER_HEADER_ONLY
+#    error "LIBEMBER_DLL may not be used in conjunction with LIBEMBER_HEADER_ONLY"
+#  endif
+#  ifdef LIBEMBER_DLL_EXPORTS           // Defined libember is being built (instead of using it)
+#    define LIBEMBER_API LIBEMBER_HELPER_DLL_EXPORT
+#  else
+#    define LIBEMBER_API LIBEMBER_HELPER_DLL_IMPORT
+#  endif
+#  define LIBEMBER_LOCAL LIBEMBER_HELPER_DLL_LOCAL
+#else                                   // If LIBEMBER_DLL is not defined this means that libember is used as a static or header only library.
+#  define LIBEMBER_API
+#  define LIBEMBER_LOCAL
+#endif
+
+#endif  // __LIBEMBER_AP_H
+

--- a/libember_slim/Source/api.h
+++ b/libember_slim/Source/api.h
@@ -1,5 +1,5 @@
 /*
-   LIBEMBER_SLIM_slim -- ANSI C implementation of the Ember+ Protocol
+   libember_slim -- ANSI C implementation of the Ember+ Protocol
    Copyright (C) 2012-2014  L-S-B Broadcast Technologies GmbH
 
    This library is free software; you can redistribute it and/or
@@ -17,8 +17,8 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef __LIBEMBER_AP_H
-#define __LIBEMBER_AP_H
+#ifndef __LIBEMBER_API_H
+#define __LIBEMBER_API_H
 
 /*
  * Preprocessor definitions for generic symbol import/export support
@@ -50,5 +50,5 @@
 #  define LIBEMBER_LOCAL
 #endif
 
-#endif  // __LIBEMBER_AP_H
+#endif  // __LIBEMBER_API_H
 

--- a/libember_slim/Source/ber.h
+++ b/libember_slim/Source/ber.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_BER_H
 #define __LIBEMBER_SLIM_BER_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 #include "bertypes.h"
 #include "bertag.h"
 #include "berio.h"
@@ -37,21 +43,21 @@
   * @param pTag pointer to the tag to get the length of.
   * @return the encoded length of the tag in bytes.
   */
-int ber_getTagLength(const BerTag *pTag);
+LIBRARY_API int ber_getTagLength(const BerTag *pTag);
 
 /**
   * Get the encoded length of @p value in bytes.
   * @param value value to get the length of.
   * @return the encoded length of the value in bytes.
   */
-int ber_getIntegerLength(berint value);
+LIBRARY_API int ber_getIntegerLength(berint value);
 
 /**
   * Get the encoded length of @p value in bytes.
   * @param value value to get the length of.
   * @return the encoded length of the value in bytes.
   */
-int ber_getLongLength(berlong value);
+LIBRARY_API int ber_getLongLength(berlong value);
 
 /**
   * Get the encoded length of a tag,length tuple in bytes.
@@ -60,7 +66,7 @@ int ber_getLongLength(berlong value);
   *      the tag,length tuple.
   * @return the encoded length of the tag,length tuple in bytes.
   */
-int ber_getHeaderLength(const BerTag *pTag, int length);
+LIBRARY_API int ber_getHeaderLength(const BerTag *pTag, int length);
 
 /**
   * Get the encoded length of a multi-byte unsigned int32
@@ -68,21 +74,21 @@ int ber_getHeaderLength(const BerTag *pTag, int length);
   * @param value the unsigned int32 to get the length of.
   * @return the encoded length of the multi-byte integer in bytes.
   */
-int ber_getMultiByteIntegerLength(dword value);
+LIBRARY_API int ber_getMultiByteIntegerLength(dword value);
 
 /**
   * Get the encoded length of a zero-terminated character string.
   * @param pValue pointer to the first character of the string.
   * @return the encoded length of the string.
   */
-int ber_getStringLength(pcstr pValue);
+LIBRARY_API int ber_getStringLength(pcstr pValue);
 
 /**
   * Get the encoded length of an integer array encoded as RELATIVE-OID.
   * @param pValue pointer to the first subidentifier of the oid.
   * @return the encoded length of the oid.
   */
-int ber_getRelativeOidLength(const berint *pValue, int count);
+LIBRARY_API int ber_getRelativeOidLength(const berint *pValue, int count);
 
 /**
   * Copies a human-readable name of the passed @p type into the buffer
@@ -91,7 +97,7 @@ int ber_getRelativeOidLength(const berint *pValue, int count);
   * @param bufferLength size of the buffer pointed to by @p pBuffer.
   * @param type the ber type to get the name of.
   */
-void ber_getTypeName(pstr pBuffer, int bufferLength, bertype type);
+LIBRARY_API void ber_getTypeName(pstr pBuffer, int bufferLength, bertype type);
 
 /**
   * Gets a pointer to a human readable, single-letter ber class
@@ -100,7 +106,7 @@ void ber_getTypeName(pstr pBuffer, int bufferLength, bertype type);
   * @return universal:"U", application:"A", etc.
   * @note the returned string must not be freed by the caller.
   */
-pcstr ber_getShortClassName(BerClass berClass);
+LIBRARY_API pcstr ber_getShortClassName(BerClass berClass);
 
 
 // ====================================================================
@@ -117,7 +123,7 @@ pcstr ber_getShortClassName(BerClass berClass);
   * @param pTag pointer to the tag to encode.
   * @return the number of bytes written to @p pOut.
   */
-int ber_encodeTag(BerOutput *pOut, const BerTag *pTag);
+LIBRARY_API int ber_encodeTag(BerOutput *pOut, const BerTag *pTag);
 
 /**
   * Encodes a ber length (as in a TLV) to the passed output.
@@ -125,7 +131,7 @@ int ber_encodeTag(BerOutput *pOut, const BerTag *pTag);
   * @param value the length to encode.
   * @return the number of bytes written to @p pOut.
   */
-int ber_encodeLength(BerOutput *pOut, int value);
+LIBRARY_API int ber_encodeLength(BerOutput *pOut, int value);
 
 /**
   * Encodes a multi-byte unsigned int32 to the passed output.
@@ -133,7 +139,7 @@ int ber_encodeLength(BerOutput *pOut, int value);
   * @param value the unsigned int32 to encode.
   * @return the number of bytes written to @p pOut.
   */
-int ber_encodeMultiByteInteger(BerOutput *pOut, dword value);
+LIBRARY_API int ber_encodeMultiByteInteger(BerOutput *pOut, dword value);
 
 /**
   * Encodes a boolean value to the passed output.
@@ -141,7 +147,7 @@ int ber_encodeMultiByteInteger(BerOutput *pOut, dword value);
   * @param value the boolean value to encode.
   * @return the number of bytes written to @p pOut.
   */
-int ber_encodeBoolean(BerOutput *pOut, bool value);
+LIBRARY_API int ber_encodeBoolean(BerOutput *pOut, bool value);
 
 /**
   * Encodes an int32 value to the passed output.
@@ -152,7 +158,7 @@ int ber_encodeBoolean(BerOutput *pOut, bool value);
   *      prior to calling this function.
   * @return the number of bytes written to @p pOut.
   */
-int ber_encodeInteger(BerOutput *pOut, berint value, int length);
+LIBRARY_API int ber_encodeInteger(BerOutput *pOut, berint value, int length);
 
 /**
   * Encodes a int64 value to the passed output.
@@ -163,7 +169,7 @@ int ber_encodeInteger(BerOutput *pOut, berint value, int length);
   *      prior to calling this function.
   * @return the number of bytes written to @p pOut.
   */
-int ber_encodeLong(BerOutput *pOut, berlong value, int length);
+LIBRARY_API int ber_encodeLong(BerOutput *pOut, berlong value, int length);
 
 /**
   * Encodes a floating-point value to the passed output.
@@ -171,7 +177,7 @@ int ber_encodeLong(BerOutput *pOut, berlong value, int length);
   * @param value the floating-point value to encode.
   * @return the number of bytes written to @p pOut.
   */
-int ber_encodeReal(BerOutput *pOut, double value);
+LIBRARY_API int ber_encodeReal(BerOutput *pOut, double value);
 
 /**
   * Encodes a zero-terminated string to the passed output.
@@ -179,7 +185,7 @@ int ber_encodeReal(BerOutput *pOut, double value);
   * @param value the zero-terminated string to encode.
   * @return the number of bytes written to @p pOut.
   */
-int ber_encodeString(BerOutput *pOut, pcstr pValue);
+LIBRARY_API int ber_encodeString(BerOutput *pOut, pcstr pValue);
 
 /**
   * Encodes an octet string value to the passed output.
@@ -190,7 +196,7 @@ int ber_encodeString(BerOutput *pOut, pcstr pValue);
   *     pointed to by @p pValue.
   * @return the number of bytes written to @p pOut.
   */
-int ber_encodeOctetString(BerOutput *pOut, const byte *pValue, int length);
+LIBRARY_API int ber_encodeOctetString(BerOutput *pOut, const byte *pValue, int length);
 
 /**
   * Encodes an relative oid value to the passed output.
@@ -200,7 +206,7 @@ int ber_encodeOctetString(BerOutput *pOut, const byte *pValue, int length);
   * @param count number of subidentifiers at @p pValue.
   * @return the number of bytes written to @p pOut.
   */
-int ber_encodeRelativeOid(BerOutput *pOut, const berint *pValue, int count);
+LIBRARY_API int ber_encodeRelativeOid(BerOutput *pOut, const berint *pValue, int count);
 
 
 
@@ -215,14 +221,14 @@ int ber_encodeRelativeOid(BerOutput *pOut, const berint *pValue, int count);
   * @param pIn pointer to the input to decode from.
   * @return the decoded tag.
   */
-BerTag ber_decodeTag(BerInput *pIn);
+LIBRARY_API BerTag ber_decodeTag(BerInput *pIn);
 
 /**
   * Decodes a ber length (as in a TLV) from the passed input.
   * @param pIn pointer to the input to decode from.
   * @return the decoded length.
   */
-int ber_decodeLength(BerInput *pIn);
+LIBRARY_API int ber_decodeLength(BerInput *pIn);
 
 /**
   * Decodes a multi-byte unsigned int32 from the passed input.
@@ -231,14 +237,14 @@ int ber_decodeLength(BerInput *pIn);
   *     the number of bytes consumed. May be NULL.
   * @return the decoded multi-byte integer.
   */
-dword ber_decodeMultiByteInteger(BerInput *pIn, int *pConsumedBytesCount);
+LIBRARY_API dword ber_decodeMultiByteInteger(BerInput *pIn, int *pConsumedBytesCount);
 
 /**
   * Decodes a boolean value from the passed input.
   * @param pIn pointer to the input to decode from.
   * @return the decoded boolean value.
   */
-bool ber_decodeBoolean(BerInput *pIn);
+LIBRARY_API bool ber_decodeBoolean(BerInput *pIn);
 
 /**
   * Decodes an int32 value from the passed input.
@@ -247,7 +253,7 @@ bool ber_decodeBoolean(BerInput *pIn);
   *     the encoding.
   * @return the decoded integer.
   */
-berint ber_decodeInteger(BerInput *pIn, int length);
+LIBRARY_API berint ber_decodeInteger(BerInput *pIn, int length);
 
 /**
   * Decodes an int64 value from the passed input.
@@ -256,7 +262,7 @@ berint ber_decodeInteger(BerInput *pIn, int length);
   *     the encoding.
   * @return the decoded integer.
   */
-berlong ber_decodeLong(BerInput *pIn, int length);
+LIBRARY_API berlong ber_decodeLong(BerInput *pIn, int length);
 
 /**
   * Decodes a floating-point value from the passed input.
@@ -265,7 +271,7 @@ berlong ber_decodeLong(BerInput *pIn, int length);
   *     the encoding.
   * @return the decoded floating-point value.
   */
-double ber_decodeReal(BerInput *pIn, int length);
+LIBRARY_API double ber_decodeReal(BerInput *pIn, int length);
 
 /**
   * Decodes a character string from the passed input into
@@ -278,7 +284,7 @@ double ber_decodeReal(BerInput *pIn, int length);
   *     @p pDest must point to a buffer big enough to hold
   *     this number of bytes.
   */
-void ber_decodeString(BerInput *pIn, pstr pDest, int length);
+LIBRARY_API void ber_decodeString(BerInput *pIn, pstr pDest, int length);
 
 /**
   * Decodes an octet string from the passed input.
@@ -289,7 +295,7 @@ void ber_decodeString(BerInput *pIn, pstr pDest, int length);
   *     @p pDest must point to a buffer big enough to hold
   *     this number of bytes.
   */
-void ber_decodeOctetString(BerInput *pIn, byte *pDest, int length);
+LIBRARY_API void ber_decodeOctetString(BerInput *pIn, byte *pDest, int length);
 
 /**
   * Decodes a relative oid value from the passed input.
@@ -301,6 +307,6 @@ void ber_decodeOctetString(BerInput *pIn, byte *pDest, int length);
   *     the encoding.
   * @return the number of decoded subidentifiers.
   */
-int ber_decodeRelativeOid(BerInput *pIn, berint *pDest, int destSize, int length);
+LIBRARY_API int ber_decodeRelativeOid(BerInput *pIn, berint *pDest, int destSize, int length);
 
 #endif

--- a/libember_slim/Source/ber.h
+++ b/libember_slim/Source/ber.h
@@ -20,12 +20,7 @@
 #ifndef __LIBEMBER_SLIM_BER_H
 #define __LIBEMBER_SLIM_BER_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
+#include "api.h"
 #include "bertypes.h"
 #include "bertag.h"
 #include "berio.h"
@@ -43,21 +38,21 @@
   * @param pTag pointer to the tag to get the length of.
   * @return the encoded length of the tag in bytes.
   */
-LIBRARY_API int ber_getTagLength(const BerTag *pTag);
+LIBEMBER_API int ber_getTagLength(const BerTag *pTag);
 
 /**
   * Get the encoded length of @p value in bytes.
   * @param value value to get the length of.
   * @return the encoded length of the value in bytes.
   */
-LIBRARY_API int ber_getIntegerLength(berint value);
+LIBEMBER_API int ber_getIntegerLength(berint value);
 
 /**
   * Get the encoded length of @p value in bytes.
   * @param value value to get the length of.
   * @return the encoded length of the value in bytes.
   */
-LIBRARY_API int ber_getLongLength(berlong value);
+LIBEMBER_API int ber_getLongLength(berlong value);
 
 /**
   * Get the encoded length of a tag,length tuple in bytes.
@@ -66,7 +61,7 @@ LIBRARY_API int ber_getLongLength(berlong value);
   *      the tag,length tuple.
   * @return the encoded length of the tag,length tuple in bytes.
   */
-LIBRARY_API int ber_getHeaderLength(const BerTag *pTag, int length);
+LIBEMBER_API int ber_getHeaderLength(const BerTag *pTag, int length);
 
 /**
   * Get the encoded length of a multi-byte unsigned int32
@@ -74,21 +69,21 @@ LIBRARY_API int ber_getHeaderLength(const BerTag *pTag, int length);
   * @param value the unsigned int32 to get the length of.
   * @return the encoded length of the multi-byte integer in bytes.
   */
-LIBRARY_API int ber_getMultiByteIntegerLength(dword value);
+LIBEMBER_API int ber_getMultiByteIntegerLength(dword value);
 
 /**
   * Get the encoded length of a zero-terminated character string.
   * @param pValue pointer to the first character of the string.
   * @return the encoded length of the string.
   */
-LIBRARY_API int ber_getStringLength(pcstr pValue);
+LIBEMBER_API int ber_getStringLength(pcstr pValue);
 
 /**
   * Get the encoded length of an integer array encoded as RELATIVE-OID.
   * @param pValue pointer to the first subidentifier of the oid.
   * @return the encoded length of the oid.
   */
-LIBRARY_API int ber_getRelativeOidLength(const berint *pValue, int count);
+LIBEMBER_API int ber_getRelativeOidLength(const berint *pValue, int count);
 
 /**
   * Copies a human-readable name of the passed @p type into the buffer
@@ -97,7 +92,7 @@ LIBRARY_API int ber_getRelativeOidLength(const berint *pValue, int count);
   * @param bufferLength size of the buffer pointed to by @p pBuffer.
   * @param type the ber type to get the name of.
   */
-LIBRARY_API void ber_getTypeName(pstr pBuffer, int bufferLength, bertype type);
+LIBEMBER_API void ber_getTypeName(pstr pBuffer, int bufferLength, bertype type);
 
 /**
   * Gets a pointer to a human readable, single-letter ber class
@@ -106,7 +101,7 @@ LIBRARY_API void ber_getTypeName(pstr pBuffer, int bufferLength, bertype type);
   * @return universal:"U", application:"A", etc.
   * @note the returned string must not be freed by the caller.
   */
-LIBRARY_API pcstr ber_getShortClassName(BerClass berClass);
+LIBEMBER_API pcstr ber_getShortClassName(BerClass berClass);
 
 
 // ====================================================================
@@ -123,7 +118,7 @@ LIBRARY_API pcstr ber_getShortClassName(BerClass berClass);
   * @param pTag pointer to the tag to encode.
   * @return the number of bytes written to @p pOut.
   */
-LIBRARY_API int ber_encodeTag(BerOutput *pOut, const BerTag *pTag);
+LIBEMBER_API int ber_encodeTag(BerOutput *pOut, const BerTag *pTag);
 
 /**
   * Encodes a ber length (as in a TLV) to the passed output.
@@ -131,7 +126,7 @@ LIBRARY_API int ber_encodeTag(BerOutput *pOut, const BerTag *pTag);
   * @param value the length to encode.
   * @return the number of bytes written to @p pOut.
   */
-LIBRARY_API int ber_encodeLength(BerOutput *pOut, int value);
+LIBEMBER_API int ber_encodeLength(BerOutput *pOut, int value);
 
 /**
   * Encodes a multi-byte unsigned int32 to the passed output.
@@ -139,7 +134,7 @@ LIBRARY_API int ber_encodeLength(BerOutput *pOut, int value);
   * @param value the unsigned int32 to encode.
   * @return the number of bytes written to @p pOut.
   */
-LIBRARY_API int ber_encodeMultiByteInteger(BerOutput *pOut, dword value);
+LIBEMBER_API int ber_encodeMultiByteInteger(BerOutput *pOut, dword value);
 
 /**
   * Encodes a boolean value to the passed output.
@@ -147,7 +142,7 @@ LIBRARY_API int ber_encodeMultiByteInteger(BerOutput *pOut, dword value);
   * @param value the boolean value to encode.
   * @return the number of bytes written to @p pOut.
   */
-LIBRARY_API int ber_encodeBoolean(BerOutput *pOut, bool value);
+LIBEMBER_API int ber_encodeBoolean(BerOutput *pOut, bool value);
 
 /**
   * Encodes an int32 value to the passed output.
@@ -158,7 +153,7 @@ LIBRARY_API int ber_encodeBoolean(BerOutput *pOut, bool value);
   *      prior to calling this function.
   * @return the number of bytes written to @p pOut.
   */
-LIBRARY_API int ber_encodeInteger(BerOutput *pOut, berint value, int length);
+LIBEMBER_API int ber_encodeInteger(BerOutput *pOut, berint value, int length);
 
 /**
   * Encodes a int64 value to the passed output.
@@ -169,7 +164,7 @@ LIBRARY_API int ber_encodeInteger(BerOutput *pOut, berint value, int length);
   *      prior to calling this function.
   * @return the number of bytes written to @p pOut.
   */
-LIBRARY_API int ber_encodeLong(BerOutput *pOut, berlong value, int length);
+LIBEMBER_API int ber_encodeLong(BerOutput *pOut, berlong value, int length);
 
 /**
   * Encodes a floating-point value to the passed output.
@@ -177,7 +172,7 @@ LIBRARY_API int ber_encodeLong(BerOutput *pOut, berlong value, int length);
   * @param value the floating-point value to encode.
   * @return the number of bytes written to @p pOut.
   */
-LIBRARY_API int ber_encodeReal(BerOutput *pOut, double value);
+LIBEMBER_API int ber_encodeReal(BerOutput *pOut, double value);
 
 /**
   * Encodes a zero-terminated string to the passed output.
@@ -185,7 +180,7 @@ LIBRARY_API int ber_encodeReal(BerOutput *pOut, double value);
   * @param value the zero-terminated string to encode.
   * @return the number of bytes written to @p pOut.
   */
-LIBRARY_API int ber_encodeString(BerOutput *pOut, pcstr pValue);
+LIBEMBER_API int ber_encodeString(BerOutput *pOut, pcstr pValue);
 
 /**
   * Encodes an octet string value to the passed output.
@@ -196,7 +191,7 @@ LIBRARY_API int ber_encodeString(BerOutput *pOut, pcstr pValue);
   *     pointed to by @p pValue.
   * @return the number of bytes written to @p pOut.
   */
-LIBRARY_API int ber_encodeOctetString(BerOutput *pOut, const byte *pValue, int length);
+LIBEMBER_API int ber_encodeOctetString(BerOutput *pOut, const byte *pValue, int length);
 
 /**
   * Encodes an relative oid value to the passed output.
@@ -206,7 +201,7 @@ LIBRARY_API int ber_encodeOctetString(BerOutput *pOut, const byte *pValue, int l
   * @param count number of subidentifiers at @p pValue.
   * @return the number of bytes written to @p pOut.
   */
-LIBRARY_API int ber_encodeRelativeOid(BerOutput *pOut, const berint *pValue, int count);
+LIBEMBER_API int ber_encodeRelativeOid(BerOutput *pOut, const berint *pValue, int count);
 
 
 
@@ -221,14 +216,14 @@ LIBRARY_API int ber_encodeRelativeOid(BerOutput *pOut, const berint *pValue, int
   * @param pIn pointer to the input to decode from.
   * @return the decoded tag.
   */
-LIBRARY_API BerTag ber_decodeTag(BerInput *pIn);
+LIBEMBER_API BerTag ber_decodeTag(BerInput *pIn);
 
 /**
   * Decodes a ber length (as in a TLV) from the passed input.
   * @param pIn pointer to the input to decode from.
   * @return the decoded length.
   */
-LIBRARY_API int ber_decodeLength(BerInput *pIn);
+LIBEMBER_API int ber_decodeLength(BerInput *pIn);
 
 /**
   * Decodes a multi-byte unsigned int32 from the passed input.
@@ -237,14 +232,14 @@ LIBRARY_API int ber_decodeLength(BerInput *pIn);
   *     the number of bytes consumed. May be NULL.
   * @return the decoded multi-byte integer.
   */
-LIBRARY_API dword ber_decodeMultiByteInteger(BerInput *pIn, int *pConsumedBytesCount);
+LIBEMBER_API dword ber_decodeMultiByteInteger(BerInput *pIn, int *pConsumedBytesCount);
 
 /**
   * Decodes a boolean value from the passed input.
   * @param pIn pointer to the input to decode from.
   * @return the decoded boolean value.
   */
-LIBRARY_API bool ber_decodeBoolean(BerInput *pIn);
+LIBEMBER_API bool ber_decodeBoolean(BerInput *pIn);
 
 /**
   * Decodes an int32 value from the passed input.
@@ -253,7 +248,7 @@ LIBRARY_API bool ber_decodeBoolean(BerInput *pIn);
   *     the encoding.
   * @return the decoded integer.
   */
-LIBRARY_API berint ber_decodeInteger(BerInput *pIn, int length);
+LIBEMBER_API berint ber_decodeInteger(BerInput *pIn, int length);
 
 /**
   * Decodes an int64 value from the passed input.
@@ -262,7 +257,7 @@ LIBRARY_API berint ber_decodeInteger(BerInput *pIn, int length);
   *     the encoding.
   * @return the decoded integer.
   */
-LIBRARY_API berlong ber_decodeLong(BerInput *pIn, int length);
+LIBEMBER_API berlong ber_decodeLong(BerInput *pIn, int length);
 
 /**
   * Decodes a floating-point value from the passed input.
@@ -271,7 +266,7 @@ LIBRARY_API berlong ber_decodeLong(BerInput *pIn, int length);
   *     the encoding.
   * @return the decoded floating-point value.
   */
-LIBRARY_API double ber_decodeReal(BerInput *pIn, int length);
+LIBEMBER_API double ber_decodeReal(BerInput *pIn, int length);
 
 /**
   * Decodes a character string from the passed input into
@@ -284,7 +279,7 @@ LIBRARY_API double ber_decodeReal(BerInput *pIn, int length);
   *     @p pDest must point to a buffer big enough to hold
   *     this number of bytes.
   */
-LIBRARY_API void ber_decodeString(BerInput *pIn, pstr pDest, int length);
+LIBEMBER_API void ber_decodeString(BerInput *pIn, pstr pDest, int length);
 
 /**
   * Decodes an octet string from the passed input.
@@ -295,7 +290,7 @@ LIBRARY_API void ber_decodeString(BerInput *pIn, pstr pDest, int length);
   *     @p pDest must point to a buffer big enough to hold
   *     this number of bytes.
   */
-LIBRARY_API void ber_decodeOctetString(BerInput *pIn, byte *pDest, int length);
+LIBEMBER_API void ber_decodeOctetString(BerInput *pIn, byte *pDest, int length);
 
 /**
   * Decodes a relative oid value from the passed input.
@@ -307,6 +302,6 @@ LIBRARY_API void ber_decodeOctetString(BerInput *pIn, byte *pDest, int length);
   *     the encoding.
   * @return the number of decoded subidentifiers.
   */
-LIBRARY_API int ber_decodeRelativeOid(BerInput *pIn, berint *pDest, int destSize, int length);
+LIBEMBER_API int ber_decodeRelativeOid(BerInput *pIn, berint *pDest, int destSize, int length);
 
 #endif

--- a/libember_slim/Source/berio.h
+++ b/libember_slim/Source/berio.h
@@ -20,13 +20,8 @@
 #ifndef __LIBEMBER_SLIM_BERIO_H
 #define __LIBEMBER_SLIM_BERIO_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
 #include <stdio.h>
+#include "api.h"
 #include "bertypes.h"
 
 // ======================================================
@@ -97,14 +92,14 @@ typedef struct SBerMemoryInput
   * @param pMemory pointer to the memory location to read from.
   * @param size number of bytes at @p pMemory.
   */
-LIBRARY_API void berMemoryInput_init(BerMemoryInput *pThis, const byte *pMemory, unsigned int size);
+LIBEMBER_API void berMemoryInput_init(BerMemoryInput *pThis, const byte *pMemory, unsigned int size);
 
 /**
   * Returns a value indicating whether all bytes from the
   * passed BerMemoryInput have been read.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API bool berMemoryInput_isEof(const struct SBerMemoryInput *pThis);
+LIBEMBER_API bool berMemoryInput_isEof(const struct SBerMemoryInput *pThis);
 
 
 // ======================================================
@@ -139,7 +134,7 @@ typedef struct SBerFileInput
   * @param pFile pointer to the io buffer to read from.
   *     Must be open and readable.
   */
-LIBRARY_API void berFileInput_init(BerFileInput *pThis, FILE *pFile);
+LIBEMBER_API void berFileInput_init(BerFileInput *pThis, FILE *pFile);
 
 
 // ======================================================
@@ -210,13 +205,13 @@ typedef struct SBerMemoryOutput
   * @param pMemory pointer to the memory location to write to.
   * @param size number of bytes at @p pMemory.
   */
-LIBRARY_API void berMemoryOutput_init(BerMemoryOutput *pThis, byte *pMemory, unsigned int size);
+LIBEMBER_API void berMemoryOutput_init(BerMemoryOutput *pThis, byte *pMemory, unsigned int size);
 
 /**
   * Resets the position of a BerMemoryOutput instance.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void berMemoryOutput_reset(BerMemoryOutput *pThis);
+LIBEMBER_API void berMemoryOutput_reset(BerMemoryOutput *pThis);
 
 
 /**
@@ -245,6 +240,6 @@ typedef struct SBerFileOutput
   * @param pFile pointer to the io buffer to write to.
   *     Must be open and writeable.
   */
-LIBRARY_API void berFileOutput_init(BerFileOutput *pThis, FILE *pFile);
+LIBEMBER_API void berFileOutput_init(BerFileOutput *pThis, FILE *pFile);
 
 #endif

--- a/libember_slim/Source/berio.h
+++ b/libember_slim/Source/berio.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_BERIO_H
 #define __LIBEMBER_SLIM_BERIO_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 #include <stdio.h>
 #include "bertypes.h"
 
@@ -91,14 +97,14 @@ typedef struct SBerMemoryInput
   * @param pMemory pointer to the memory location to read from.
   * @param size number of bytes at @p pMemory.
   */
-void berMemoryInput_init(BerMemoryInput *pThis, const byte *pMemory, unsigned int size);
+LIBRARY_API void berMemoryInput_init(BerMemoryInput *pThis, const byte *pMemory, unsigned int size);
 
 /**
   * Returns a value indicating whether all bytes from the
   * passed BerMemoryInput have been read.
   * @param pThis pointer to the object to process.
   */
-bool berMemoryInput_isEof(const struct SBerMemoryInput *pThis);
+LIBRARY_API bool berMemoryInput_isEof(const struct SBerMemoryInput *pThis);
 
 
 // ======================================================
@@ -133,7 +139,7 @@ typedef struct SBerFileInput
   * @param pFile pointer to the io buffer to read from.
   *     Must be open and readable.
   */
-void berFileInput_init(BerFileInput *pThis, FILE *pFile);
+LIBRARY_API void berFileInput_init(BerFileInput *pThis, FILE *pFile);
 
 
 // ======================================================
@@ -204,13 +210,13 @@ typedef struct SBerMemoryOutput
   * @param pMemory pointer to the memory location to write to.
   * @param size number of bytes at @p pMemory.
   */
-void berMemoryOutput_init(BerMemoryOutput *pThis, byte *pMemory, unsigned int size);
+LIBRARY_API void berMemoryOutput_init(BerMemoryOutput *pThis, byte *pMemory, unsigned int size);
 
 /**
   * Resets the position of a BerMemoryOutput instance.
   * @param pThis pointer to the object to process.
   */
-void berMemoryOutput_reset(BerMemoryOutput *pThis);
+LIBRARY_API void berMemoryOutput_reset(BerMemoryOutput *pThis);
 
 
 /**
@@ -239,6 +245,6 @@ typedef struct SBerFileOutput
   * @param pFile pointer to the io buffer to write to.
   *     Must be open and writeable.
   */
-void berFileOutput_init(BerFileOutput *pThis, FILE *pFile);
+LIBRARY_API void berFileOutput_init(BerFileOutput *pThis, FILE *pFile);
 
 #endif

--- a/libember_slim/Source/berreader.h
+++ b/libember_slim/Source/berreader.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_BERREADER_H
 #define __LIBEMBER_SLIM_BERREADER_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 #include "bertypes.h"
 #include "bytebuffer.h"
 #include "bertag.h"
@@ -69,21 +75,21 @@ typedef struct SBerReader
   * BerReader instance are invoked.
   * @param pThis pointer to the object to process.
   */
-void berReader_init(BerReader *pThis);
+LIBRARY_API void berReader_init(BerReader *pThis);
 
 /**
   * Frees all memory allocated by a BerReader instance.
   * BerReader instance are invoked.
   * @param pThis pointer to the object to process.
   */
-void berReader_free(BerReader *pThis);
+LIBRARY_API void berReader_free(BerReader *pThis);
 
 /**
   * Resets a BerReader instance.
   * Clears all fields except the buffer.
   * @param pThis pointer to the object to process.
   */
-void berReader_reset(BerReader *pThis);
+LIBRARY_API void berReader_reset(BerReader *pThis);
 
 /**
   * Gets the value of the current TLTLV as a boolean.
@@ -91,7 +97,7 @@ void berReader_reset(BerReader *pThis);
   * @param pThis pointer to the object to process.
   * @return the decoded value.
   */
-bool berReader_getBoolean(const BerReader *pThis);
+LIBRARY_API bool berReader_getBoolean(const BerReader *pThis);
 
 /**
   * Gets the value of the current TLTLV as an int32.
@@ -99,7 +105,7 @@ bool berReader_getBoolean(const BerReader *pThis);
   * @param pThis pointer to the object to process.
   * @return the decoded value.
   */
-berint berReader_getInteger(const BerReader *pThis);
+LIBRARY_API berint berReader_getInteger(const BerReader *pThis);
 
 /**
   * Gets the value of the current TLTLV as a int64.
@@ -107,7 +113,7 @@ berint berReader_getInteger(const BerReader *pThis);
   * @param pThis pointer to the object to process.
   * @return the decoded value.
   */
-berlong berReader_getLong(const BerReader *pThis);
+LIBRARY_API berlong berReader_getLong(const BerReader *pThis);
 
 /**
   * Gets the value of the current TLTLV as a double.
@@ -115,7 +121,7 @@ berlong berReader_getLong(const BerReader *pThis);
   * @param pThis pointer to the object to process.
   * @return the decoded value.
   */
-double berReader_getReal(const BerReader *pThis);
+LIBRARY_API double berReader_getReal(const BerReader *pThis);
 
 /**
   * Gets the value of the current TLTLV as a zero-terminated utf-8 string.
@@ -127,7 +133,7 @@ double berReader_getReal(const BerReader *pThis);
   * @note Currently libember_slim only supports the ASCII character
   *     range (0 through 127).
   */
-void berReader_getString(const BerReader *pThis, pstr pDest, int size);
+LIBRARY_API void berReader_getString(const BerReader *pThis, pstr pDest, int size);
 
 /**
   * Gets the value of the current TLTLV as a byte array.
@@ -138,7 +144,7 @@ void berReader_getString(const BerReader *pThis, pstr pDest, int size);
   *     of @p size characters will be stored at @p pDest.
   * @return number of decoded octets.
   */
-int berReader_getOctetString(const BerReader *pThis, byte *pDest, int size);
+LIBRARY_API int berReader_getOctetString(const BerReader *pThis, byte *pDest, int size);
 
 /**
   * Gets the value of the current TLTLV as a an array of integers,
@@ -152,6 +158,6 @@ int berReader_getOctetString(const BerReader *pThis, byte *pDest, int size);
   * @note This function slightly bends the ASN.1 standard and
   *     is subject to be removed.
   */
-int berReader_getRelativeOid(const BerReader *pThis, berint *pDest, int destSize);
+LIBRARY_API int berReader_getRelativeOid(const BerReader *pThis, berint *pDest, int destSize);
 
 #endif

--- a/libember_slim/Source/berreader.h
+++ b/libember_slim/Source/berreader.h
@@ -20,12 +20,7 @@
 #ifndef __LIBEMBER_SLIM_BERREADER_H
 #define __LIBEMBER_SLIM_BERREADER_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
+#include "api.h"
 #include "bertypes.h"
 #include "bytebuffer.h"
 #include "bertag.h"
@@ -75,21 +70,21 @@ typedef struct SBerReader
   * BerReader instance are invoked.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void berReader_init(BerReader *pThis);
+LIBEMBER_API void berReader_init(BerReader *pThis);
 
 /**
   * Frees all memory allocated by a BerReader instance.
   * BerReader instance are invoked.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void berReader_free(BerReader *pThis);
+LIBEMBER_API void berReader_free(BerReader *pThis);
 
 /**
   * Resets a BerReader instance.
   * Clears all fields except the buffer.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void berReader_reset(BerReader *pThis);
+LIBEMBER_API void berReader_reset(BerReader *pThis);
 
 /**
   * Gets the value of the current TLTLV as a boolean.
@@ -97,7 +92,7 @@ LIBRARY_API void berReader_reset(BerReader *pThis);
   * @param pThis pointer to the object to process.
   * @return the decoded value.
   */
-LIBRARY_API bool berReader_getBoolean(const BerReader *pThis);
+LIBEMBER_API bool berReader_getBoolean(const BerReader *pThis);
 
 /**
   * Gets the value of the current TLTLV as an int32.
@@ -105,7 +100,7 @@ LIBRARY_API bool berReader_getBoolean(const BerReader *pThis);
   * @param pThis pointer to the object to process.
   * @return the decoded value.
   */
-LIBRARY_API berint berReader_getInteger(const BerReader *pThis);
+LIBEMBER_API berint berReader_getInteger(const BerReader *pThis);
 
 /**
   * Gets the value of the current TLTLV as a int64.
@@ -113,7 +108,7 @@ LIBRARY_API berint berReader_getInteger(const BerReader *pThis);
   * @param pThis pointer to the object to process.
   * @return the decoded value.
   */
-LIBRARY_API berlong berReader_getLong(const BerReader *pThis);
+LIBEMBER_API berlong berReader_getLong(const BerReader *pThis);
 
 /**
   * Gets the value of the current TLTLV as a double.
@@ -121,7 +116,7 @@ LIBRARY_API berlong berReader_getLong(const BerReader *pThis);
   * @param pThis pointer to the object to process.
   * @return the decoded value.
   */
-LIBRARY_API double berReader_getReal(const BerReader *pThis);
+LIBEMBER_API double berReader_getReal(const BerReader *pThis);
 
 /**
   * Gets the value of the current TLTLV as a zero-terminated utf-8 string.
@@ -133,7 +128,7 @@ LIBRARY_API double berReader_getReal(const BerReader *pThis);
   * @note Currently libember_slim only supports the ASCII character
   *     range (0 through 127).
   */
-LIBRARY_API void berReader_getString(const BerReader *pThis, pstr pDest, int size);
+LIBEMBER_API void berReader_getString(const BerReader *pThis, pstr pDest, int size);
 
 /**
   * Gets the value of the current TLTLV as a byte array.
@@ -144,7 +139,7 @@ LIBRARY_API void berReader_getString(const BerReader *pThis, pstr pDest, int siz
   *     of @p size characters will be stored at @p pDest.
   * @return number of decoded octets.
   */
-LIBRARY_API int berReader_getOctetString(const BerReader *pThis, byte *pDest, int size);
+LIBEMBER_API int berReader_getOctetString(const BerReader *pThis, byte *pDest, int size);
 
 /**
   * Gets the value of the current TLTLV as a an array of integers,
@@ -158,6 +153,6 @@ LIBRARY_API int berReader_getOctetString(const BerReader *pThis, byte *pDest, in
   * @note This function slightly bends the ASN.1 standard and
   *     is subject to be removed.
   */
-LIBRARY_API int berReader_getRelativeOid(const BerReader *pThis, berint *pDest, int destSize);
+LIBEMBER_API int berReader_getRelativeOid(const BerReader *pThis, berint *pDest, int destSize);
 
 #endif

--- a/libember_slim/Source/bertag.h
+++ b/libember_slim/Source/bertag.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_BERTAG_H
 #define __LIBEMBER_SLIM_BERTAG_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 #include "bertypes.h"
 
 // ======================================================
@@ -132,7 +138,7 @@ typedef struct SBerTag
   * @berClass the tag class to initialize BerTag.preamble with.
   * @param number the tag number to initialize BerTag.number with.
   */
-void berTag_init(BerTag *pThis, BerClass berClass, tagnumber number);
+LIBRARY_API void berTag_init(BerTag *pThis, BerClass berClass, tagnumber number);
 
 /**
   * Gets a value indicating whether the passed tag has the
@@ -140,35 +146,35 @@ void berTag_init(BerTag *pThis, BerClass berClass, tagnumber number);
   * @param pThis pointer to the object to process.
   * @return True if the passed tag has the container flag set.
   */
-bool berTag_isContainer(const BerTag *pThis);
+LIBRARY_API bool berTag_isContainer(const BerTag *pThis);
 
 /**
   * Sets a value indicating whether the passed tag has the
   * container flag set.
   * @param pThis pointer to the object to process.
   */
-void berTag_setContainer(BerTag *pThis, bool value);
+LIBRARY_API void berTag_setContainer(BerTag *pThis, bool value);
 
 /**
   * Gets the ber class of the passed tag.
   * @param pThis pointer to the object to process.
   * @return The ber class of the passed tag.
   */
-BerClass berTag_getClass(const BerTag *pThis);
+LIBRARY_API BerClass berTag_getClass(const BerTag *pThis);
 
 /**
   * Sets the ber class of the passed tag.
   * @param pThis pointer to the object to process.
   * @param value The new ber class to set.
   */
-void berTag_setClass(BerTag *pThis, BerClass value);
+LIBRARY_API void berTag_setClass(BerTag *pThis, BerClass value);
 
 /**
   * Sets the ber class of the passed tag.
   * @param pThis pointer to the object to process.
   * @param value The new ber class to set.
   */
-bool berTag_isZero(const BerTag *pThis);
+LIBRARY_API bool berTag_isZero(const BerTag *pThis);
 
 /**
   * Converts the passed tag to a tag with the same class
@@ -177,7 +183,7 @@ bool berTag_isZero(const BerTag *pThis);
   * @return A copy of the tag pointed to by @p pThis with
   *      the container flag set.
   */
-BerTag berTag_toContainer(const BerTag *pThis);
+LIBRARY_API BerTag berTag_toContainer(const BerTag *pThis);
 
 /**
   * Gets the number of the tag as a bertype value,
@@ -188,7 +194,7 @@ BerTag berTag_toContainer(const BerTag *pThis);
   *      APPLICATION-1 will be returned as (BerType_ApplicationFlag | 1).
   *      UNIVERSAL-1 will be returned as 1.
   */
-bertype berTag_numberAsType(const BerTag *pThis);
+LIBRARY_API bertype berTag_numberAsType(const BerTag *pThis);
 
 #ifdef SECURE_CRT
 /**
@@ -198,7 +204,7 @@ bertype berTag_numberAsType(const BerTag *pThis);
   * @param pBuffer pointer to the buffer to store
   *      the zero-terminated string to.
   */
-void berTag_toString(const BerTag *pThis, pstr pBuffer, int bufferSize);
+LIBRARY_API void berTag_toString(const BerTag *pThis, pstr pBuffer, int bufferSize);
 #else
 /**
   * Writes a human-readable string representation of
@@ -209,7 +215,7 @@ void berTag_toString(const BerTag *pThis, pstr pBuffer, int bufferSize);
   * @param bufferSize size of the buffer pointed to
   *      by @p pBuffer.
   */
-void berTag_toString(const BerTag *pThis, pstr pBuffer);
+LIBRARY_API void berTag_toString(const BerTag *pThis, pstr pBuffer);
 #endif
 
 /**
@@ -218,6 +224,6 @@ void berTag_toString(const BerTag *pThis, pstr pBuffer);
   * @param pThis pointer to the object to process.
   * @param pThat pointer to the BerTag to compare to @p pThis.
   */
-bool berTag_equals(const BerTag *pThis, const BerTag *pThat);
+LIBRARY_API bool berTag_equals(const BerTag *pThis, const BerTag *pThat);
 
 #endif

--- a/libember_slim/Source/bertag.h
+++ b/libember_slim/Source/bertag.h
@@ -20,12 +20,7 @@
 #ifndef __LIBEMBER_SLIM_BERTAG_H
 #define __LIBEMBER_SLIM_BERTAG_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
+#include "api.h"
 #include "bertypes.h"
 
 // ======================================================
@@ -138,7 +133,7 @@ typedef struct SBerTag
   * @berClass the tag class to initialize BerTag.preamble with.
   * @param number the tag number to initialize BerTag.number with.
   */
-LIBRARY_API void berTag_init(BerTag *pThis, BerClass berClass, tagnumber number);
+LIBEMBER_API void berTag_init(BerTag *pThis, BerClass berClass, tagnumber number);
 
 /**
   * Gets a value indicating whether the passed tag has the
@@ -146,35 +141,35 @@ LIBRARY_API void berTag_init(BerTag *pThis, BerClass berClass, tagnumber number)
   * @param pThis pointer to the object to process.
   * @return True if the passed tag has the container flag set.
   */
-LIBRARY_API bool berTag_isContainer(const BerTag *pThis);
+LIBEMBER_API bool berTag_isContainer(const BerTag *pThis);
 
 /**
   * Sets a value indicating whether the passed tag has the
   * container flag set.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void berTag_setContainer(BerTag *pThis, bool value);
+LIBEMBER_API void berTag_setContainer(BerTag *pThis, bool value);
 
 /**
   * Gets the ber class of the passed tag.
   * @param pThis pointer to the object to process.
   * @return The ber class of the passed tag.
   */
-LIBRARY_API BerClass berTag_getClass(const BerTag *pThis);
+LIBEMBER_API BerClass berTag_getClass(const BerTag *pThis);
 
 /**
   * Sets the ber class of the passed tag.
   * @param pThis pointer to the object to process.
   * @param value The new ber class to set.
   */
-LIBRARY_API void berTag_setClass(BerTag *pThis, BerClass value);
+LIBEMBER_API void berTag_setClass(BerTag *pThis, BerClass value);
 
 /**
   * Sets the ber class of the passed tag.
   * @param pThis pointer to the object to process.
   * @param value The new ber class to set.
   */
-LIBRARY_API bool berTag_isZero(const BerTag *pThis);
+LIBEMBER_API bool berTag_isZero(const BerTag *pThis);
 
 /**
   * Converts the passed tag to a tag with the same class
@@ -183,7 +178,7 @@ LIBRARY_API bool berTag_isZero(const BerTag *pThis);
   * @return A copy of the tag pointed to by @p pThis with
   *      the container flag set.
   */
-LIBRARY_API BerTag berTag_toContainer(const BerTag *pThis);
+LIBEMBER_API BerTag berTag_toContainer(const BerTag *pThis);
 
 /**
   * Gets the number of the tag as a bertype value,
@@ -194,7 +189,7 @@ LIBRARY_API BerTag berTag_toContainer(const BerTag *pThis);
   *      APPLICATION-1 will be returned as (BerType_ApplicationFlag | 1).
   *      UNIVERSAL-1 will be returned as 1.
   */
-LIBRARY_API bertype berTag_numberAsType(const BerTag *pThis);
+LIBEMBER_API bertype berTag_numberAsType(const BerTag *pThis);
 
 #ifdef SECURE_CRT
 /**
@@ -204,7 +199,7 @@ LIBRARY_API bertype berTag_numberAsType(const BerTag *pThis);
   * @param pBuffer pointer to the buffer to store
   *      the zero-terminated string to.
   */
-LIBRARY_API void berTag_toString(const BerTag *pThis, pstr pBuffer, int bufferSize);
+LIBEMBER_API void berTag_toString(const BerTag *pThis, pstr pBuffer, int bufferSize);
 #else
 /**
   * Writes a human-readable string representation of
@@ -215,7 +210,7 @@ LIBRARY_API void berTag_toString(const BerTag *pThis, pstr pBuffer, int bufferSi
   * @param bufferSize size of the buffer pointed to
   *      by @p pBuffer.
   */
-LIBRARY_API void berTag_toString(const BerTag *pThis, pstr pBuffer);
+LIBEMBER_API void berTag_toString(const BerTag *pThis, pstr pBuffer);
 #endif
 
 /**
@@ -224,6 +219,6 @@ LIBRARY_API void berTag_toString(const BerTag *pThis, pstr pBuffer);
   * @param pThis pointer to the object to process.
   * @param pThat pointer to the BerTag to compare to @p pThis.
   */
-LIBRARY_API bool berTag_equals(const BerTag *pThis, const BerTag *pThat);
+LIBEMBER_API bool berTag_equals(const BerTag *pThis, const BerTag *pThat);
 
 #endif

--- a/libember_slim/Source/bytebuffer.h
+++ b/libember_slim/Source/bytebuffer.h
@@ -20,12 +20,7 @@
 #ifndef __LIBEMBER_SLIM_BYTEBUFFER_H
 #define __LIBEMBER_SLIM_BYTEBUFFER_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
+#include "api.h"
 #include "bertypes.h"
 
 /**
@@ -63,7 +58,7 @@ typedef struct SByteBuffer
   * @pMemory the address of the memory chunk allocated for the buffer.
   * @param size the size of the memory chunk at @p pMemory in bytes.
   */
-LIBRARY_API void byteBuffer_init(ByteBuffer *pThis, byte *pMemory, unsigned int size);
+LIBEMBER_API void byteBuffer_init(ByteBuffer *pThis, byte *pMemory, unsigned int size);
 
 /**
   * Initializes a dynamic ByteBuffer instance, which allocates
@@ -73,7 +68,7 @@ LIBRARY_API void byteBuffer_init(ByteBuffer *pThis, byte *pMemory, unsigned int 
   * @param pThis pointer to the object to process.
   * @param size the initial size of the buffer.
   */
-LIBRARY_API void byteBuffer_initDynamic(ByteBuffer *pThis, unsigned int size);
+LIBEMBER_API void byteBuffer_initDynamic(ByteBuffer *pThis, unsigned int size);
 
 /**
   * Add a byte to the buffer, advancing the write position.
@@ -82,13 +77,13 @@ LIBRARY_API void byteBuffer_initDynamic(ByteBuffer *pThis, unsigned int size);
   * @note If the buffer is full, this operation calls the
   *     throwError callback.
   */
-LIBRARY_API void byteBuffer_add(ByteBuffer *pThis, byte b);
+LIBEMBER_API void byteBuffer_add(ByteBuffer *pThis, byte b);
 
 /**
   * Resets the write position to the begin of the buffer.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void byteBuffer_reset(ByteBuffer *pThis);
+LIBEMBER_API void byteBuffer_reset(ByteBuffer *pThis);
 
 /**
   * Ensures that the size of the dynamic buffer is at least @p size bytes.
@@ -96,7 +91,7 @@ LIBRARY_API void byteBuffer_reset(ByteBuffer *pThis);
   * @param pThis pointer to the object to process.
   * @param size new size of the buffer.
   */
-LIBRARY_API void byteBuffer_resize(ByteBuffer *pThis, unsigned int size);
+LIBEMBER_API void byteBuffer_resize(ByteBuffer *pThis, unsigned int size);
 
 /**
   * Gets a value indicating whether the passed byte buffer
@@ -105,12 +100,12 @@ LIBRARY_API void byteBuffer_resize(ByteBuffer *pThis, unsigned int size);
   * @return True if the byte buffer's write cursor is past the
   *      end of the buffer, otherwise false.
   */
-LIBRARY_API bool byteBuffer_isEmpty(const ByteBuffer *pThis);
+LIBEMBER_API bool byteBuffer_isEmpty(const ByteBuffer *pThis);
 
 /**
   * Frees all memory allocated by the dynamic buffer.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void byteBuffer_free(ByteBuffer *pThis);
+LIBEMBER_API void byteBuffer_free(ByteBuffer *pThis);
 
 #endif

--- a/libember_slim/Source/bytebuffer.h
+++ b/libember_slim/Source/bytebuffer.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_BYTEBUFFER_H
 #define __LIBEMBER_SLIM_BYTEBUFFER_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 #include "bertypes.h"
 
 /**
@@ -57,7 +63,7 @@ typedef struct SByteBuffer
   * @pMemory the address of the memory chunk allocated for the buffer.
   * @param size the size of the memory chunk at @p pMemory in bytes.
   */
-void byteBuffer_init(ByteBuffer *pThis, byte *pMemory, unsigned int size);
+LIBRARY_API void byteBuffer_init(ByteBuffer *pThis, byte *pMemory, unsigned int size);
 
 /**
   * Initializes a dynamic ByteBuffer instance, which allocates
@@ -67,7 +73,7 @@ void byteBuffer_init(ByteBuffer *pThis, byte *pMemory, unsigned int size);
   * @param pThis pointer to the object to process.
   * @param size the initial size of the buffer.
   */
-void byteBuffer_initDynamic(ByteBuffer *pThis, unsigned int size);
+LIBRARY_API void byteBuffer_initDynamic(ByteBuffer *pThis, unsigned int size);
 
 /**
   * Add a byte to the buffer, advancing the write position.
@@ -76,13 +82,13 @@ void byteBuffer_initDynamic(ByteBuffer *pThis, unsigned int size);
   * @note If the buffer is full, this operation calls the
   *     throwError callback.
   */
-void byteBuffer_add(ByteBuffer *pThis, byte b);
+LIBRARY_API void byteBuffer_add(ByteBuffer *pThis, byte b);
 
 /**
   * Resets the write position to the begin of the buffer.
   * @param pThis pointer to the object to process.
   */
-void byteBuffer_reset(ByteBuffer *pThis);
+LIBRARY_API void byteBuffer_reset(ByteBuffer *pThis);
 
 /**
   * Ensures that the size of the dynamic buffer is at least @p size bytes.
@@ -90,7 +96,7 @@ void byteBuffer_reset(ByteBuffer *pThis);
   * @param pThis pointer to the object to process.
   * @param size new size of the buffer.
   */
-void byteBuffer_resize(ByteBuffer *pThis, unsigned int size);
+LIBRARY_API void byteBuffer_resize(ByteBuffer *pThis, unsigned int size);
 
 /**
   * Gets a value indicating whether the passed byte buffer
@@ -99,12 +105,12 @@ void byteBuffer_resize(ByteBuffer *pThis, unsigned int size);
   * @return True if the byte buffer's write cursor is past the
   *      end of the buffer, otherwise false.
   */
-bool byteBuffer_isEmpty(const ByteBuffer *pThis);
+LIBRARY_API bool byteBuffer_isEmpty(const ByteBuffer *pThis);
 
 /**
   * Frees all memory allocated by the dynamic buffer.
   * @param pThis pointer to the object to process.
   */
-void byteBuffer_free(ByteBuffer *pThis);
+LIBRARY_API void byteBuffer_free(ByteBuffer *pThis);
 
 #endif

--- a/libember_slim/Source/ember.c
+++ b/libember_slim/Source/ember.c
@@ -19,6 +19,7 @@
 
 #include <string.h>
 #include "ember.h"
+#include "emberplus.h"
 #include "emberinternal.h"
 
 

--- a/libember_slim/Source/ember.h
+++ b/libember_slim/Source/ember.h
@@ -20,12 +20,7 @@
 #ifndef __LIBEMBER_SLIM_EMBER_H
 #define __LIBEMBER_SLIM_EMBER_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
+#include "api.h"
 #include "ber.h"
 #include "emberasyncreader.h"
 #include "emberframing.h"
@@ -94,7 +89,7 @@ typedef void (*freeMemory_t)(void *pMemory);
   * @note Each call to ember_WriteContainerBegin must be matched
   *      with a later call to ember_WriteContainerEnd.
   */
-LIBRARY_API void ember_writeContainerBegin(BerOutput *pOut, const BerTag *pTag, bertype type);
+LIBEMBER_API void ember_writeContainerBegin(BerOutput *pOut, const BerTag *pTag, bertype type);
 
 /**
   * Writes the begin TLTL of a SEQUENCE. Shortcut for
@@ -105,7 +100,7 @@ LIBRARY_API void ember_writeContainerBegin(BerOutput *pOut, const BerTag *pTag, 
   * @note Each call to ember_WriteSequenceBegin must be matched
   *      with a later call to ember_WriteContainerEnd.
   */
-LIBRARY_API void ember_writeSequenceBegin(BerOutput *pOut, const BerTag *pTag);
+LIBEMBER_API void ember_writeSequenceBegin(BerOutput *pOut, const BerTag *pTag);
 
 /**
   * Writes the begin TLTL of a SET. Shortcut for
@@ -116,7 +111,7 @@ LIBRARY_API void ember_writeSequenceBegin(BerOutput *pOut, const BerTag *pTag);
   * @note Each call to ember_WriteSetBegin must be matched
   *      with a later call to ember_WriteContainerEnd.
   */
-LIBRARY_API void ember_writeSetBegin(BerOutput *pOut, const BerTag *pTag);
+LIBEMBER_API void ember_writeSetBegin(BerOutput *pOut, const BerTag *pTag);
 
 /**
   * Writes a container terminator.
@@ -124,7 +119,7 @@ LIBRARY_API void ember_writeSetBegin(BerOutput *pOut, const BerTag *pTag);
   * @note Each call to ember_WriteContainerEnd must
   *      be matched with a prior call to ember_WriteContainerBegin.
   */
-LIBRARY_API void ember_writeContainerEnd(BerOutput *pOut);
+LIBEMBER_API void ember_writeContainerEnd(BerOutput *pOut);
 
 /**
   * Writes a TLTLV with a boolean value, using the definite
@@ -134,7 +129,7 @@ LIBRARY_API void ember_writeContainerEnd(BerOutput *pOut);
   * @param pTag pointer to the outer tag of the TLTLV.
   * @param value the value to write.
   */
-LIBRARY_API void ember_writeBoolean(BerOutput *pOut, const BerTag *pTag, bool value);
+LIBEMBER_API void ember_writeBoolean(BerOutput *pOut, const BerTag *pTag, bool value);
 
 /**
   * Writes a TLTLV with an int32 value, using the definite
@@ -144,7 +139,7 @@ LIBRARY_API void ember_writeBoolean(BerOutput *pOut, const BerTag *pTag, bool va
   * @param pTag pointer to the outer tag of the TLTLV.
   * @param value the value to write.
   */
-LIBRARY_API void ember_writeInteger(BerOutput *pOut, const BerTag *pTag, berint value);
+LIBEMBER_API void ember_writeInteger(BerOutput *pOut, const BerTag *pTag, berint value);
 
 /**
   * Writes a TLTLV with a int64 value, using the definite
@@ -154,7 +149,7 @@ LIBRARY_API void ember_writeInteger(BerOutput *pOut, const BerTag *pTag, berint 
   * @param pTag pointer to the outer tag of the TLTLV.
   * @param value the value to write.
   */
-LIBRARY_API void ember_writeLong(BerOutput *pOut, const BerTag *pTag, berlong value);
+LIBEMBER_API void ember_writeLong(BerOutput *pOut, const BerTag *pTag, berlong value);
 
 /**
   * Writes a TLTLV with a double value, using the definite
@@ -164,7 +159,7 @@ LIBRARY_API void ember_writeLong(BerOutput *pOut, const BerTag *pTag, berlong va
   * @param pTag pointer to the outer tag of the TLTLV.
   * @param value the value to write.
   */
-LIBRARY_API void ember_writeReal(BerOutput *pOut, const BerTag *pTag, double value);
+LIBEMBER_API void ember_writeReal(BerOutput *pOut, const BerTag *pTag, double value);
 
 /**
   * Writes a TLTLV with a zero-terminated string value, using the definite
@@ -176,7 +171,7 @@ LIBRARY_API void ember_writeReal(BerOutput *pOut, const BerTag *pTag, double val
   * @param pValue pointer to the first character of
   *      the zero-terminated string to write.
   */
-LIBRARY_API void ember_writeString(BerOutput *pOut, const BerTag *pTag, pcstr pValue);
+LIBEMBER_API void ember_writeString(BerOutput *pOut, const BerTag *pTag, pcstr pValue);
 
 /**
   * Writes a TLTLV with an octet string value, using the definite
@@ -187,7 +182,7 @@ LIBRARY_API void ember_writeString(BerOutput *pOut, const BerTag *pTag, pcstr pV
   * @param pValue pointer to the first byte of the octet
   *      string to write.
   */
-LIBRARY_API void ember_writeOctetString(BerOutput *pOut, const BerTag *pTag, const byte *pValue, int valueLength);
+LIBEMBER_API void ember_writeOctetString(BerOutput *pOut, const BerTag *pTag, const byte *pValue, int valueLength);
 
 /**
   * Writes a TLTLV with a RelativeOid value, using the definite
@@ -197,6 +192,6 @@ LIBRARY_API void ember_writeOctetString(BerOutput *pOut, const BerTag *pTag, con
   * @param pTag pointer to the outer tag of the TLTLV.
   * @param pValue pointer to the first subidentifier of the RelativeOid.
   */
-LIBRARY_API void ember_writeRelativeOid(BerOutput *pOut, const BerTag *pTag, const berint *pValue, int count);
+LIBEMBER_API void ember_writeRelativeOid(BerOutput *pOut, const BerTag *pTag, const berint *pValue, int count);
 
 #endif

--- a/libember_slim/Source/ember.h
+++ b/libember_slim/Source/ember.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_EMBER_H
 #define __LIBEMBER_SLIM_EMBER_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 #include "ber.h"
 #include "emberasyncreader.h"
 #include "emberframing.h"
@@ -88,7 +94,7 @@ typedef void (*freeMemory_t)(void *pMemory);
   * @note Each call to ember_WriteContainerBegin must be matched
   *      with a later call to ember_WriteContainerEnd.
   */
-void ember_writeContainerBegin(BerOutput *pOut, const BerTag *pTag, bertype type);
+LIBRARY_API void ember_writeContainerBegin(BerOutput *pOut, const BerTag *pTag, bertype type);
 
 /**
   * Writes the begin TLTL of a SEQUENCE. Shortcut for
@@ -99,7 +105,7 @@ void ember_writeContainerBegin(BerOutput *pOut, const BerTag *pTag, bertype type
   * @note Each call to ember_WriteSequenceBegin must be matched
   *      with a later call to ember_WriteContainerEnd.
   */
-void ember_writeSequenceBegin(BerOutput *pOut, const BerTag *pTag);
+LIBRARY_API void ember_writeSequenceBegin(BerOutput *pOut, const BerTag *pTag);
 
 /**
   * Writes the begin TLTL of a SET. Shortcut for
@@ -110,7 +116,7 @@ void ember_writeSequenceBegin(BerOutput *pOut, const BerTag *pTag);
   * @note Each call to ember_WriteSetBegin must be matched
   *      with a later call to ember_WriteContainerEnd.
   */
-void ember_writeSetBegin(BerOutput *pOut, const BerTag *pTag);
+LIBRARY_API void ember_writeSetBegin(BerOutput *pOut, const BerTag *pTag);
 
 /**
   * Writes a container terminator.
@@ -118,7 +124,7 @@ void ember_writeSetBegin(BerOutput *pOut, const BerTag *pTag);
   * @note Each call to ember_WriteContainerEnd must
   *      be matched with a prior call to ember_WriteContainerBegin.
   */
-void ember_writeContainerEnd(BerOutput *pOut);
+LIBRARY_API void ember_writeContainerEnd(BerOutput *pOut);
 
 /**
   * Writes a TLTLV with a boolean value, using the definite
@@ -128,7 +134,7 @@ void ember_writeContainerEnd(BerOutput *pOut);
   * @param pTag pointer to the outer tag of the TLTLV.
   * @param value the value to write.
   */
-void ember_writeBoolean(BerOutput *pOut, const BerTag *pTag, bool value);
+LIBRARY_API void ember_writeBoolean(BerOutput *pOut, const BerTag *pTag, bool value);
 
 /**
   * Writes a TLTLV with an int32 value, using the definite
@@ -138,7 +144,7 @@ void ember_writeBoolean(BerOutput *pOut, const BerTag *pTag, bool value);
   * @param pTag pointer to the outer tag of the TLTLV.
   * @param value the value to write.
   */
-void ember_writeInteger(BerOutput *pOut, const BerTag *pTag, berint value);
+LIBRARY_API void ember_writeInteger(BerOutput *pOut, const BerTag *pTag, berint value);
 
 /**
   * Writes a TLTLV with a int64 value, using the definite
@@ -148,7 +154,7 @@ void ember_writeInteger(BerOutput *pOut, const BerTag *pTag, berint value);
   * @param pTag pointer to the outer tag of the TLTLV.
   * @param value the value to write.
   */
-void ember_writeLong(BerOutput *pOut, const BerTag *pTag, berlong value);
+LIBRARY_API void ember_writeLong(BerOutput *pOut, const BerTag *pTag, berlong value);
 
 /**
   * Writes a TLTLV with a double value, using the definite
@@ -158,7 +164,7 @@ void ember_writeLong(BerOutput *pOut, const BerTag *pTag, berlong value);
   * @param pTag pointer to the outer tag of the TLTLV.
   * @param value the value to write.
   */
-void ember_writeReal(BerOutput *pOut, const BerTag *pTag, double value);
+LIBRARY_API void ember_writeReal(BerOutput *pOut, const BerTag *pTag, double value);
 
 /**
   * Writes a TLTLV with a zero-terminated string value, using the definite
@@ -170,7 +176,7 @@ void ember_writeReal(BerOutput *pOut, const BerTag *pTag, double value);
   * @param pValue pointer to the first character of
   *      the zero-terminated string to write.
   */
-void ember_writeString(BerOutput *pOut, const BerTag *pTag, pcstr pValue);
+LIBRARY_API void ember_writeString(BerOutput *pOut, const BerTag *pTag, pcstr pValue);
 
 /**
   * Writes a TLTLV with an octet string value, using the definite
@@ -181,7 +187,7 @@ void ember_writeString(BerOutput *pOut, const BerTag *pTag, pcstr pValue);
   * @param pValue pointer to the first byte of the octet
   *      string to write.
   */
-void ember_writeOctetString(BerOutput *pOut, const BerTag *pTag, const byte *pValue, int valueLength);
+LIBRARY_API void ember_writeOctetString(BerOutput *pOut, const BerTag *pTag, const byte *pValue, int valueLength);
 
 /**
   * Writes a TLTLV with a RelativeOid value, using the definite
@@ -191,6 +197,6 @@ void ember_writeOctetString(BerOutput *pOut, const BerTag *pTag, const byte *pVa
   * @param pTag pointer to the outer tag of the TLTLV.
   * @param pValue pointer to the first subidentifier of the RelativeOid.
   */
-void ember_writeRelativeOid(BerOutput *pOut, const BerTag *pTag, const berint *pValue, int count);
+LIBRARY_API void ember_writeRelativeOid(BerOutput *pOut, const BerTag *pTag, const berint *pValue, int count);
 
 #endif

--- a/libember_slim/Source/emberasyncreader.h
+++ b/libember_slim/Source/emberasyncreader.h
@@ -20,12 +20,7 @@
 #ifndef __LIBEMBER_SLIM_EMBERASYNCREADER_H
 #define __LIBEMBER_SLIM_EMBERASYNCREADER_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
+#include "api.h"
 #include "berreader.h"
 
 #ifndef EMBER_MAX_TREE_DEPTH
@@ -148,7 +143,7 @@ typedef struct SEmberAsyncReader
   * EmberAsyncReader instance are invoked.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void emberAsyncReader_init(EmberAsyncReader *pThis);
+LIBEMBER_API void emberAsyncReader_init(EmberAsyncReader *pThis);
 
 /**
   * Frees all dynamically allocated memory used by the
@@ -156,7 +151,7 @@ LIBRARY_API void emberAsyncReader_init(EmberAsyncReader *pThis);
   * by a prior call to emberAsyncReader_init.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void emberAsyncReader_free(EmberAsyncReader *pThis);
+LIBEMBER_API void emberAsyncReader_free(EmberAsyncReader *pThis);
 
 /**
   * Feeds a single input byte into the reader. If this byte completes
@@ -166,7 +161,7 @@ LIBRARY_API void emberAsyncReader_free(EmberAsyncReader *pThis);
   * @param pThis pointer to the object to process.
   * @param b The input byte to process.</param>
   */
-LIBRARY_API void emberAsyncReader_readByte(EmberAsyncReader *pThis, byte b);
+LIBEMBER_API void emberAsyncReader_readByte(EmberAsyncReader *pThis, byte b);
 
 /**
   * Feeds a multiple input bytes into the reader. Everytime a complete
@@ -177,12 +172,12 @@ LIBRARY_API void emberAsyncReader_readByte(EmberAsyncReader *pThis, byte b);
   * @param pBytes pointer to the first byte to feed to @p pThis.</param>
   * @param count number of bytes to feed to @p pThis.</param>
   */
-LIBRARY_API void emberAsyncReader_readBytes(EmberAsyncReader *pThis, const byte *pBytes, int count);
+LIBEMBER_API void emberAsyncReader_readBytes(EmberAsyncReader *pThis, const byte *pBytes, int count);
 
 /**
   * Resets the internal state of the passed EmberAsyncReader.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void emberAsyncReader_reset(EmberAsyncReader *pThis);
+LIBEMBER_API void emberAsyncReader_reset(EmberAsyncReader *pThis);
 
 #endif

--- a/libember_slim/Source/emberasyncreader.h
+++ b/libember_slim/Source/emberasyncreader.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_EMBERASYNCREADER_H
 #define __LIBEMBER_SLIM_EMBERASYNCREADER_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 #include "berreader.h"
 
 #ifndef EMBER_MAX_TREE_DEPTH
@@ -142,7 +148,7 @@ typedef struct SEmberAsyncReader
   * EmberAsyncReader instance are invoked.
   * @param pThis pointer to the object to process.
   */
-void emberAsyncReader_init(EmberAsyncReader *pThis);
+LIBRARY_API void emberAsyncReader_init(EmberAsyncReader *pThis);
 
 /**
   * Frees all dynamically allocated memory used by the
@@ -150,7 +156,7 @@ void emberAsyncReader_init(EmberAsyncReader *pThis);
   * by a prior call to emberAsyncReader_init.
   * @param pThis pointer to the object to process.
   */
-void emberAsyncReader_free(EmberAsyncReader *pThis);
+LIBRARY_API void emberAsyncReader_free(EmberAsyncReader *pThis);
 
 /**
   * Feeds a single input byte into the reader. If this byte completes
@@ -160,7 +166,7 @@ void emberAsyncReader_free(EmberAsyncReader *pThis);
   * @param pThis pointer to the object to process.
   * @param b The input byte to process.</param>
   */
-void emberAsyncReader_readByte(EmberAsyncReader *pThis, byte b);
+LIBRARY_API void emberAsyncReader_readByte(EmberAsyncReader *pThis, byte b);
 
 /**
   * Feeds a multiple input bytes into the reader. Everytime a complete
@@ -171,12 +177,12 @@ void emberAsyncReader_readByte(EmberAsyncReader *pThis, byte b);
   * @param pBytes pointer to the first byte to feed to @p pThis.</param>
   * @param count number of bytes to feed to @p pThis.</param>
   */
-void emberAsyncReader_readBytes(EmberAsyncReader *pThis, const byte *pBytes, int count);
+LIBRARY_API void emberAsyncReader_readBytes(EmberAsyncReader *pThis, const byte *pBytes, int count);
 
 /**
   * Resets the internal state of the passed EmberAsyncReader.
   * @param pThis pointer to the object to process.
   */
-void emberAsyncReader_reset(EmberAsyncReader *pThis);
+LIBRARY_API void emberAsyncReader_reset(EmberAsyncReader *pThis);
 
 #endif

--- a/libember_slim/Source/emberframing.c
+++ b/libember_slim/Source/emberframing.c
@@ -85,7 +85,7 @@ static const unsigned short _crcTable[256] =
 
 static unsigned short crc_addByte(unsigned short crc, byte b)
 {
-   return (unsigned short)((crc >> 8) ^ _crcTable[(byte)(crc ^ b)]);
+   return (unsigned short)((crc >> 8) ^ _crcTable[(byte)((crc ^ b) & 0xFF)]);
 }
 
 

--- a/libember_slim/Source/emberframing.h
+++ b/libember_slim/Source/emberframing.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_EMBERFRAMING_H
 #define __LIBEMBER_SLIM_EMBERFRAMING_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 #include "berio.h"
 
 
@@ -137,7 +143,7 @@ typedef struct SBerFramingOutput
   * @param appBytesCount number of application-defined bytes at
   *     @p pAppBytes.
   */
-void berFramingOutput_init(BerFramingOutput *pThis,
+LIBRARY_API void berFramingOutput_init(BerFramingOutput *pThis,
                            byte *pMemory,
                            unsigned int size,
                            byte slotId,
@@ -152,7 +158,7 @@ void berFramingOutput_init(BerFramingOutput *pThis,
   * @param pThis pointer to the object to process.
   * @param flags contains a combination of package flags
   */
-void berFramingOutput_writeHeader(BerFramingOutput *pThis, EmberFramingFlags flags);
+LIBRARY_API void berFramingOutput_writeHeader(BerFramingOutput *pThis, EmberFramingFlags flags);
 
 /**
   * Finishes the framed package. After this function
@@ -164,7 +170,7 @@ void berFramingOutput_writeHeader(BerFramingOutput *pThis, EmberFramingFlags fla
   * @note you need to call this function when you have
   *     written a complete ember tree to @p pThis.
   */
-unsigned int berFramingOutput_finish(BerFramingOutput *pThis);
+LIBRARY_API unsigned int berFramingOutput_finish(BerFramingOutput *pThis);
 
 
 // ======================================================
@@ -182,7 +188,7 @@ unsigned int berFramingOutput_finish(BerFramingOutput *pThis);
   * @param slotId the S101 slot id of the remote host.
   * @return the number of bytes written to @p pBuffer.
   */
-unsigned int emberFraming_writeKeepAliveRequest(byte *pBuffer, unsigned int size, byte slotId);
+LIBRARY_API unsigned int emberFraming_writeKeepAliveRequest(byte *pBuffer, unsigned int size, byte slotId);
 
 /**
   * Frames a Keep-Alive Response message into the passed buffer.
@@ -193,7 +199,7 @@ unsigned int emberFraming_writeKeepAliveRequest(byte *pBuffer, unsigned int size
   * @param slotId the S101 slot id of the remote host.
   * @return the number of bytes written to @p pBuffer.
   */
-unsigned int emberFraming_writeKeepAliveResponse(byte *pBuffer, unsigned int size, byte slotId);
+LIBRARY_API unsigned int emberFraming_writeKeepAliveResponse(byte *pBuffer, unsigned int size, byte slotId);
 
 
 // ======================================================
@@ -258,7 +264,7 @@ typedef struct SEmberFramingReader
   *     function called when a complete package has been unframed.
   * @param state application-defined argument passed to onPackageReceived.
   */
-void emberFramingReader_init(EmberFramingReader *pThis,
+LIBRARY_API void emberFramingReader_init(EmberFramingReader *pThis,
                              byte *pMemory,
                              unsigned int size,
                              onPackageReceived_t onPackageReceived,
@@ -270,7 +276,7 @@ void emberFramingReader_init(EmberFramingReader *pThis,
   * can be unframed.
   * @param pThis pointer to the object to process.
   */
-void emberFramingReader_reset(EmberFramingReader *pThis);
+LIBRARY_API void emberFramingReader_reset(EmberFramingReader *pThis);
 
 /**
   * Feeds multiple bytes of framed data into an EmberFramingReader
@@ -281,6 +287,6 @@ void emberFramingReader_reset(EmberFramingReader *pThis);
   * @param count number of bytes at @p pBytes to feed into the
   *     reader.
   */
-void emberFramingReader_readBytes(EmberFramingReader *pThis, const byte *pBytes, int count);
+LIBRARY_API void emberFramingReader_readBytes(EmberFramingReader *pThis, const byte *pBytes, int count);
 
 #endif

--- a/libember_slim/Source/emberframing.h
+++ b/libember_slim/Source/emberframing.h
@@ -20,12 +20,7 @@
 #ifndef __LIBEMBER_SLIM_EMBERFRAMING_H
 #define __LIBEMBER_SLIM_EMBERFRAMING_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
+#include "api.h"
 #include "berio.h"
 
 
@@ -143,7 +138,7 @@ typedef struct SBerFramingOutput
   * @param appBytesCount number of application-defined bytes at
   *     @p pAppBytes.
   */
-LIBRARY_API void berFramingOutput_init(BerFramingOutput *pThis,
+LIBEMBER_API void berFramingOutput_init(BerFramingOutput *pThis,
                            byte *pMemory,
                            unsigned int size,
                            byte slotId,
@@ -158,7 +153,7 @@ LIBRARY_API void berFramingOutput_init(BerFramingOutput *pThis,
   * @param pThis pointer to the object to process.
   * @param flags contains a combination of package flags
   */
-LIBRARY_API void berFramingOutput_writeHeader(BerFramingOutput *pThis, EmberFramingFlags flags);
+LIBEMBER_API void berFramingOutput_writeHeader(BerFramingOutput *pThis, EmberFramingFlags flags);
 
 /**
   * Finishes the framed package. After this function
@@ -170,7 +165,7 @@ LIBRARY_API void berFramingOutput_writeHeader(BerFramingOutput *pThis, EmberFram
   * @note you need to call this function when you have
   *     written a complete ember tree to @p pThis.
   */
-LIBRARY_API unsigned int berFramingOutput_finish(BerFramingOutput *pThis);
+LIBEMBER_API unsigned int berFramingOutput_finish(BerFramingOutput *pThis);
 
 
 // ======================================================
@@ -188,7 +183,7 @@ LIBRARY_API unsigned int berFramingOutput_finish(BerFramingOutput *pThis);
   * @param slotId the S101 slot id of the remote host.
   * @return the number of bytes written to @p pBuffer.
   */
-LIBRARY_API unsigned int emberFraming_writeKeepAliveRequest(byte *pBuffer, unsigned int size, byte slotId);
+LIBEMBER_API unsigned int emberFraming_writeKeepAliveRequest(byte *pBuffer, unsigned int size, byte slotId);
 
 /**
   * Frames a Keep-Alive Response message into the passed buffer.
@@ -199,7 +194,7 @@ LIBRARY_API unsigned int emberFraming_writeKeepAliveRequest(byte *pBuffer, unsig
   * @param slotId the S101 slot id of the remote host.
   * @return the number of bytes written to @p pBuffer.
   */
-LIBRARY_API unsigned int emberFraming_writeKeepAliveResponse(byte *pBuffer, unsigned int size, byte slotId);
+LIBEMBER_API unsigned int emberFraming_writeKeepAliveResponse(byte *pBuffer, unsigned int size, byte slotId);
 
 
 // ======================================================
@@ -264,7 +259,7 @@ typedef struct SEmberFramingReader
   *     function called when a complete package has been unframed.
   * @param state application-defined argument passed to onPackageReceived.
   */
-LIBRARY_API void emberFramingReader_init(EmberFramingReader *pThis,
+LIBEMBER_API void emberFramingReader_init(EmberFramingReader *pThis,
                              byte *pMemory,
                              unsigned int size,
                              onPackageReceived_t onPackageReceived,
@@ -276,7 +271,7 @@ LIBRARY_API void emberFramingReader_init(EmberFramingReader *pThis,
   * can be unframed.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void emberFramingReader_reset(EmberFramingReader *pThis);
+LIBEMBER_API void emberFramingReader_reset(EmberFramingReader *pThis);
 
 /**
   * Feeds multiple bytes of framed data into an EmberFramingReader
@@ -287,6 +282,6 @@ LIBRARY_API void emberFramingReader_reset(EmberFramingReader *pThis);
   * @param count number of bytes at @p pBytes to feed into the
   *     reader.
   */
-LIBRARY_API void emberFramingReader_readBytes(EmberFramingReader *pThis, const byte *pBytes, int count);
+LIBEMBER_API void emberFramingReader_readBytes(EmberFramingReader *pThis, const byte *pBytes, int count);
 
 #endif

--- a/libember_slim/Source/emberplus.h
+++ b/libember_slim/Source/emberplus.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_EMBERPLUS_H
 #define __LIBEMBER_SLIM_EMBERPLUS_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 /**
   * The version of the library implementation as an uint16.
   * The upper byte is the major version number.
@@ -40,7 +46,7 @@
   * @param allocMemory the callback to invoke for memory allocation.
   * @param freeMemory the callback to invoke to free memory.
   */
-void ember_init(throwError_t throwError,
+LIBRARY_API void ember_init(throwError_t throwError,
                 failAssertion_t failAssertion,
                 allocMemory_t allocMemory,
                 freeMemory_t freeMemory);

--- a/libember_slim/Source/emberplus.h
+++ b/libember_slim/Source/emberplus.h
@@ -20,12 +20,6 @@
 #ifndef __LIBEMBER_SLIM_EMBERPLUS_H
 #define __LIBEMBER_SLIM_EMBERPLUS_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
 /**
   * The version of the library implementation as an uint16.
   * The upper byte is the major version number.
@@ -33,6 +27,7 @@
   */
 #define EMBER_LIBRARY_VERSION (0x0146) //1.70
 
+#include "api.h"
 #include "glowtx.h"
 #include "glowrx.h"
 
@@ -46,7 +41,7 @@
   * @param allocMemory the callback to invoke for memory allocation.
   * @param freeMemory the callback to invoke to free memory.
   */
-LIBRARY_API void ember_init(throwError_t throwError,
+LIBEMBER_API void ember_init(throwError_t throwError,
                 failAssertion_t failAssertion,
                 allocMemory_t allocMemory,
                 freeMemory_t freeMemory);

--- a/libember_slim/Source/glow.h
+++ b/libember_slim/Source/glow.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_GLOW_H
 #define __LIBEMBER_SLIM_GLOW_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 #include "ember.h"
 
 
@@ -491,7 +497,7 @@ typedef struct SGlowNode
   * Frees all memory allocated by a GlowNode instance.
   * @param pThis pointer to the object to process.
   */
-void glowNode_free(GlowNode *pThis);
+LIBRARY_API void glowNode_free(GlowNode *pThis);
 
 
 /**
@@ -556,7 +562,7 @@ typedef struct SGlowValue
   * @param pThis pointer to the object to process.
   * @param pDest pointer to the source value.
   */
-void glowValue_copyFrom(GlowValue *pThis, const GlowValue *pSource);
+LIBRARY_API void glowValue_copyFrom(GlowValue *pThis, const GlowValue *pSource);
 
 #define glowValue_copyTo(pSource, pDest) glowValue_copyFrom(pDest, pSource)
 
@@ -565,7 +571,7 @@ void glowValue_copyFrom(GlowValue *pThis, const GlowValue *pSource);
   * Frees all memory allocated by a GlowValue instance.
   * @param pThis pointer to the object to process.
   */
-void glowValue_free(GlowValue *pThis);
+LIBRARY_API void glowValue_free(GlowValue *pThis);
 
 
 /**
@@ -683,7 +689,7 @@ typedef struct SGlowParameter
   * Frees all memory allocated by a GlowValue instance.
   * @param pThis pointer to the object to process.
   */
-void glowParameter_free(GlowParameter *pThis);
+LIBRARY_API void glowParameter_free(GlowParameter *pThis);
 
 
 /**
@@ -714,7 +720,7 @@ typedef struct SGlowInvocation
   * Frees all memory allocated by a GlowInvocation instance.
   * @param pThis pointer to the object to process.
   */
-void glowInvocation_free(GlowInvocation *pThis);
+LIBRARY_API void glowInvocation_free(GlowInvocation *pThis);
 
 
 /**
@@ -749,7 +755,7 @@ typedef struct SGlowCommand
   * Frees all memory allocated by a GlowCommand instance.
   * @param pThis pointer to the object to process.
   */
-void glowCommand_free(GlowCommand *pThis);
+LIBRARY_API void glowCommand_free(GlowCommand *pThis);
 
 
 /**
@@ -828,7 +834,7 @@ typedef struct SGlowParametersLocation
 /**
   * Returns true if pThis points to a valid (initialized) GlowParametersLocation struct.
   */
-bool glowParametersLocation_isValid(const GlowParametersLocation *pThis);
+LIBRARY_API bool glowParametersLocation_isValid(const GlowParametersLocation *pThis);
 
 
 /**
@@ -911,7 +917,7 @@ typedef struct SGlowMatrix
   * Frees all memory allocated by a GlowMatrix instance.
   * @param pThis pointer to the object to process.
   */
-void glowMatrix_free(GlowMatrix *pThis);
+LIBRARY_API void glowMatrix_free(GlowMatrix *pThis);
 
 
 /**
@@ -951,7 +957,7 @@ typedef struct SGlowConnection
   * Frees all memory allocated by a GlowMatrix instance.
   * @param pThis pointer to the object to process.
   */
-void glowConnection_free(GlowConnection *pThis);
+LIBRARY_API void glowConnection_free(GlowConnection *pThis);
 
 
 /**
@@ -988,7 +994,7 @@ typedef struct SGlowTupleItemDescription
   * Frees all memory allocated by a GlowTupleItemDescription instance.
   * @param pThis pointer to the object to process.
   */
-void glowTupleItemDescription_free(GlowTupleItemDescription *pThis);
+LIBRARY_API void glowTupleItemDescription_free(GlowTupleItemDescription *pThis);
 
 
 /**
@@ -1034,7 +1040,7 @@ typedef struct SGlowFunction
   * Frees all memory allocated by a GlowFunction instance.
   * @param pThis pointer to the object to process.
   */
-void glowFunction_free(GlowFunction *pThis);
+LIBRARY_API void glowFunction_free(GlowFunction *pThis);
 
 
 /**
@@ -1069,6 +1075,6 @@ typedef struct SGlowInvocationResult
   * Frees all memory allocated by a GlowInvocationResult instance.
   * @param pThis pointer to the object to process.
   */
-void glowInvocationResult_free(GlowInvocationResult *pThis);
+LIBRARY_API void glowInvocationResult_free(GlowInvocationResult *pThis);
 
 #endif// __LIBEMBER_SLIM_GLOW_H

--- a/libember_slim/Source/glow.h
+++ b/libember_slim/Source/glow.h
@@ -20,12 +20,7 @@
 #ifndef __LIBEMBER_SLIM_GLOW_H
 #define __LIBEMBER_SLIM_GLOW_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
+#include "api.h"
 #include "ember.h"
 
 
@@ -497,7 +492,7 @@ typedef struct SGlowNode
   * Frees all memory allocated by a GlowNode instance.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowNode_free(GlowNode *pThis);
+LIBEMBER_API void glowNode_free(GlowNode *pThis);
 
 
 /**
@@ -562,7 +557,7 @@ typedef struct SGlowValue
   * @param pThis pointer to the object to process.
   * @param pDest pointer to the source value.
   */
-LIBRARY_API void glowValue_copyFrom(GlowValue *pThis, const GlowValue *pSource);
+LIBEMBER_API void glowValue_copyFrom(GlowValue *pThis, const GlowValue *pSource);
 
 #define glowValue_copyTo(pSource, pDest) glowValue_copyFrom(pDest, pSource)
 
@@ -571,7 +566,7 @@ LIBRARY_API void glowValue_copyFrom(GlowValue *pThis, const GlowValue *pSource);
   * Frees all memory allocated by a GlowValue instance.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowValue_free(GlowValue *pThis);
+LIBEMBER_API void glowValue_free(GlowValue *pThis);
 
 
 /**
@@ -689,7 +684,7 @@ typedef struct SGlowParameter
   * Frees all memory allocated by a GlowValue instance.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowParameter_free(GlowParameter *pThis);
+LIBEMBER_API void glowParameter_free(GlowParameter *pThis);
 
 
 /**
@@ -720,7 +715,7 @@ typedef struct SGlowInvocation
   * Frees all memory allocated by a GlowInvocation instance.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowInvocation_free(GlowInvocation *pThis);
+LIBEMBER_API void glowInvocation_free(GlowInvocation *pThis);
 
 
 /**
@@ -755,7 +750,7 @@ typedef struct SGlowCommand
   * Frees all memory allocated by a GlowCommand instance.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowCommand_free(GlowCommand *pThis);
+LIBEMBER_API void glowCommand_free(GlowCommand *pThis);
 
 
 /**
@@ -834,7 +829,7 @@ typedef struct SGlowParametersLocation
 /**
   * Returns true if pThis points to a valid (initialized) GlowParametersLocation struct.
   */
-LIBRARY_API bool glowParametersLocation_isValid(const GlowParametersLocation *pThis);
+LIBEMBER_API bool glowParametersLocation_isValid(const GlowParametersLocation *pThis);
 
 
 /**
@@ -917,7 +912,7 @@ typedef struct SGlowMatrix
   * Frees all memory allocated by a GlowMatrix instance.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowMatrix_free(GlowMatrix *pThis);
+LIBEMBER_API void glowMatrix_free(GlowMatrix *pThis);
 
 
 /**
@@ -957,7 +952,7 @@ typedef struct SGlowConnection
   * Frees all memory allocated by a GlowMatrix instance.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowConnection_free(GlowConnection *pThis);
+LIBEMBER_API void glowConnection_free(GlowConnection *pThis);
 
 
 /**
@@ -994,7 +989,7 @@ typedef struct SGlowTupleItemDescription
   * Frees all memory allocated by a GlowTupleItemDescription instance.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowTupleItemDescription_free(GlowTupleItemDescription *pThis);
+LIBEMBER_API void glowTupleItemDescription_free(GlowTupleItemDescription *pThis);
 
 
 /**
@@ -1040,7 +1035,7 @@ typedef struct SGlowFunction
   * Frees all memory allocated by a GlowFunction instance.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowFunction_free(GlowFunction *pThis);
+LIBEMBER_API void glowFunction_free(GlowFunction *pThis);
 
 
 /**
@@ -1075,6 +1070,6 @@ typedef struct SGlowInvocationResult
   * Frees all memory allocated by a GlowInvocationResult instance.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowInvocationResult_free(GlowInvocationResult *pThis);
+LIBEMBER_API void glowInvocationResult_free(GlowInvocationResult *pThis);
 
 #endif// __LIBEMBER_SLIM_GLOW_H

--- a/libember_slim/Source/glowrx.h
+++ b/libember_slim/Source/glowrx.h
@@ -20,12 +20,7 @@
 #ifndef __LIBEMBER_SLIM_GLOWRX_H
 #define __LIBEMBER_SLIM_GLOWRX_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
+#include "api.h"
 #include "glow.h"
 
 // ====================================================================
@@ -352,7 +347,7 @@ typedef struct SNonFramingGlowReader
   * @note you need to call nonFramingGlowReader_free to release
   *     all memory allocated by nonFramingGlowReader_init.
   */
-LIBRARY_API void nonFramingGlowReader_init(NonFramingGlowReader *pThis,
+LIBEMBER_API void nonFramingGlowReader_init(NonFramingGlowReader *pThis,
                                onNode_t onNode,
                                onParameter_t onParameter,
                                onCommand_t onCommand,
@@ -365,13 +360,13 @@ LIBRARY_API void nonFramingGlowReader_init(NonFramingGlowReader *pThis,
   * by a prior call to nonFramingGlowReader_init.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void nonFramingGlowReader_free(NonFramingGlowReader *pThis);
+LIBEMBER_API void nonFramingGlowReader_free(NonFramingGlowReader *pThis);
 
 /**
   * Resets the internal state of the passedNonFramingGlowReader.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void nonFramingGlowReader_reset(NonFramingGlowReader *pThis);
+LIBEMBER_API void nonFramingGlowReader_reset(NonFramingGlowReader *pThis);
 
 
 // ====================================================================
@@ -432,7 +427,7 @@ typedef struct SGlowReader
   * @note you need to call glowReader_free to release
   *     all memory allocated by glowReader_init.
   */
-LIBRARY_API void glowReader_init(GlowReader *pThis,
+LIBEMBER_API void glowReader_init(GlowReader *pThis,
                      onNode_t onNode,
                      onParameter_t onParameter,
                      onCommand_t onCommand,
@@ -447,7 +442,7 @@ LIBRARY_API void glowReader_init(GlowReader *pThis,
   * by a prior call to GlowReader_init.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowReader_free(GlowReader *pThis);
+LIBEMBER_API void glowReader_free(GlowReader *pThis);
 
 /**
   * Feeds multiple bytes of framed Ember data using the Glow DTD into
@@ -459,12 +454,12 @@ LIBRARY_API void glowReader_free(GlowReader *pThis);
   * @param pBytes pointer to the first byte to feed.
   * @param count the number of bytes at @p pBytes to feed.
   */
-LIBRARY_API void glowReader_readBytes(GlowReader *pThis, const byte *pBytes, int count);
+LIBEMBER_API void glowReader_readBytes(GlowReader *pThis, const byte *pBytes, int count);
 
 /**
   * Resets the internal state of the passed GlowReader.
   * @param pThis pointer to the object to process.
   */
-LIBRARY_API void glowReader_reset(GlowReader *pThis);
+LIBEMBER_API void glowReader_reset(GlowReader *pThis);
 
 #endif//__LIBEMBER_SLIM_GLOWRX_H

--- a/libember_slim/Source/glowrx.h
+++ b/libember_slim/Source/glowrx.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_GLOWRX_H
 #define __LIBEMBER_SLIM_GLOWRX_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 #include "glow.h"
 
 // ====================================================================
@@ -346,7 +352,7 @@ typedef struct SNonFramingGlowReader
   * @note you need to call nonFramingGlowReader_free to release
   *     all memory allocated by nonFramingGlowReader_init.
   */
-void nonFramingGlowReader_init(NonFramingGlowReader *pThis,
+LIBRARY_API void nonFramingGlowReader_init(NonFramingGlowReader *pThis,
                                onNode_t onNode,
                                onParameter_t onParameter,
                                onCommand_t onCommand,
@@ -359,13 +365,13 @@ void nonFramingGlowReader_init(NonFramingGlowReader *pThis,
   * by a prior call to nonFramingGlowReader_init.
   * @param pThis pointer to the object to process.
   */
-void nonFramingGlowReader_free(NonFramingGlowReader *pThis);
+LIBRARY_API void nonFramingGlowReader_free(NonFramingGlowReader *pThis);
 
 /**
   * Resets the internal state of the passedNonFramingGlowReader.
   * @param pThis pointer to the object to process.
   */
-void nonFramingGlowReader_reset(NonFramingGlowReader *pThis);
+LIBRARY_API void nonFramingGlowReader_reset(NonFramingGlowReader *pThis);
 
 
 // ====================================================================
@@ -426,7 +432,7 @@ typedef struct SGlowReader
   * @note you need to call glowReader_free to release
   *     all memory allocated by glowReader_init.
   */
-void glowReader_init(GlowReader *pThis,
+LIBRARY_API void glowReader_init(GlowReader *pThis,
                      onNode_t onNode,
                      onParameter_t onParameter,
                      onCommand_t onCommand,
@@ -441,7 +447,7 @@ void glowReader_init(GlowReader *pThis,
   * by a prior call to GlowReader_init.
   * @param pThis pointer to the object to process.
   */
-void glowReader_free(GlowReader *pThis);
+LIBRARY_API void glowReader_free(GlowReader *pThis);
 
 /**
   * Feeds multiple bytes of framed Ember data using the Glow DTD into
@@ -453,12 +459,12 @@ void glowReader_free(GlowReader *pThis);
   * @param pBytes pointer to the first byte to feed.
   * @param count the number of bytes at @p pBytes to feed.
   */
-void glowReader_readBytes(GlowReader *pThis, const byte *pBytes, int count);
+LIBRARY_API void glowReader_readBytes(GlowReader *pThis, const byte *pBytes, int count);
 
 /**
   * Resets the internal state of the passed GlowReader.
   * @param pThis pointer to the object to process.
   */
-void glowReader_reset(GlowReader *pThis);
+LIBRARY_API void glowReader_reset(GlowReader *pThis);
 
 #endif//__LIBEMBER_SLIM_GLOWRX_H

--- a/libember_slim/Source/glowtx.h
+++ b/libember_slim/Source/glowtx.h
@@ -20,12 +20,7 @@
 #ifndef __LIBEMBER_SLIM_GLOWTX_H
 #define __LIBEMBER_SLIM_GLOWTX_H
 
-#ifdef LIBEMBER_DLL_EXPORTS
-#define LIBRARY_API __declspec(dllexport)
-#else
-#define LIBRARY_API
-#endif
-
+#include "api.h"
 #include "glow.h"
 
 // ====================================================================
@@ -78,7 +73,7 @@ typedef struct SGlowOutput
   * @param slotId the slot id as described in the
   *     framing protocol documentation.
   */
-LIBRARY_API void glowOutput_init(GlowOutput *pThis,
+LIBEMBER_API void glowOutput_init(GlowOutput *pThis,
                      byte *pMemory,
                      unsigned int size,
                      byte slotId);
@@ -91,7 +86,7 @@ LIBRARY_API void glowOutput_init(GlowOutput *pThis,
   * @param isLastPackage if true, the EmberFramingFlag_LastPackage flag
   *     is set in the header.
   */
-LIBRARY_API void glowOutput_beginPackage(GlowOutput *pThis, bool isLastPackage);
+LIBEMBER_API void glowOutput_beginPackage(GlowOutput *pThis, bool isLastPackage);
 
 /**
   * Begins a new package by writing the framing header and the start tag
@@ -101,7 +96,7 @@ LIBRARY_API void glowOutput_beginPackage(GlowOutput *pThis, bool isLastPackage);
   * @param isLastPackage if true, the EmberFramingFlag_LastPackage flag
   *     is set in the header.
   */
-LIBRARY_API void glowOutput_beginStreamPackage(GlowOutput *pThis, bool isLastPackage);
+LIBEMBER_API void glowOutput_beginStreamPackage(GlowOutput *pThis, bool isLastPackage);
 
 /**
   * Finishes the framed package. After this function
@@ -113,7 +108,7 @@ LIBRARY_API void glowOutput_beginStreamPackage(GlowOutput *pThis, bool isLastPac
   * @note you need to call this function when you have
   *     written a complete glow tree to @p pThis.
   */
-LIBRARY_API unsigned int glowOutput_finishPackage(GlowOutput *pThis);
+LIBEMBER_API unsigned int glowOutput_finishPackage(GlowOutput *pThis);
 
 
 // ====================================================================
@@ -135,7 +130,7 @@ LIBRARY_API unsigned int glowOutput_finishPackage(GlowOutput *pThis);
   *     number. May be NULL only if pathLength is 0.
   * @param pathLength number of node numbers at @p pPath.
   */
-LIBRARY_API void glow_writeQualifiedNode(GlowOutput *pOut,
+LIBEMBER_API void glow_writeQualifiedNode(GlowOutput *pOut,
                              const GlowNode *pNode,
                              GlowFieldFlags fields,
                              const berint *pPath,
@@ -154,7 +149,7 @@ LIBRARY_API void glow_writeQualifiedNode(GlowOutput *pOut,
   *     number. May be NULL only if pathLength is 0.
   * @param pathLength number of node numbers at @p pPath.
   */
-LIBRARY_API void glow_writeQualifiedParameter(GlowOutput *pOut,
+LIBEMBER_API void glow_writeQualifiedParameter(GlowOutput *pOut,
                                   const GlowParameter *pParameter,
                                   GlowFieldFlags fields,
                                   const berint *pPath,
@@ -183,7 +178,7 @@ LIBRARY_API void glow_writeQualifiedParameter(GlowOutput *pOut,
   *     - parentType = GlowElementType_Matrix:
   *       command is nested in a QualifiedMatrix
   */
-LIBRARY_API void glow_writeQualifiedCommand(GlowOutput *pOut,
+LIBEMBER_API void glow_writeQualifiedCommand(GlowOutput *pOut,
                                 const GlowCommand *pCommand,
                                 const berint *pPath,
                                 int pathLength,
@@ -194,7 +189,7 @@ LIBRARY_API void glow_writeQualifiedCommand(GlowOutput *pOut,
   * @param pOut pointer to the output to be used for in-memory framing.
   * @param pEntry pointer to GlowStreamEntry object to write.
   */
-LIBRARY_API void glow_writeStreamEntry(GlowOutput *pOut, const GlowStreamEntry *pEntry);
+LIBEMBER_API void glow_writeStreamEntry(GlowOutput *pOut, const GlowStreamEntry *pEntry);
 
 /**
   * Writes a Matrix to the passed GlowOutput, encoding @p pMatrix
@@ -212,7 +207,7 @@ LIBRARY_API void glow_writeStreamEntry(GlowOutput *pOut, const GlowStreamEntry *
   *     This is encoded in the "path" field of the QualifiedMatrix.
   * @param pathLength number of node numbers at @p pPath.
   */
-LIBRARY_API void glow_writeQualifiedMatrix(GlowOutput *pOut,
+LIBEMBER_API void glow_writeQualifiedMatrix(GlowOutput *pOut,
                                const GlowMatrix *pMatrix,
                                GlowFieldFlags fields,
                                const berint *pPath,
@@ -227,7 +222,7 @@ LIBRARY_API void glow_writeQualifiedMatrix(GlowOutput *pOut,
   *     This is encoded in the "path" field of the QualifiedMatrix.
   * @param matrixPathLength number of node numbers at @p pPath.
   */
-LIBRARY_API void glow_writeTargetsPrefix(GlowOutput *pOut,
+LIBEMBER_API void glow_writeTargetsPrefix(GlowOutput *pOut,
                              const berint *pMatrixPath,
                              int matrixPathLength);
 
@@ -237,7 +232,7 @@ LIBRARY_API void glow_writeTargetsPrefix(GlowOutput *pOut,
   * @param pOut pointer to the output to be used for in-memory framing.
   * @param pConnection pointer to the target to write.
   */
-LIBRARY_API void glow_writeTarget(GlowOutput *pOut, const GlowSignal *pTarget);
+LIBEMBER_API void glow_writeTarget(GlowOutput *pOut, const GlowSignal *pTarget);
 
 /**
   * Writes the suffix for the "targets" sequence of a QualifiedMatrix.
@@ -245,7 +240,7 @@ LIBRARY_API void glow_writeTarget(GlowOutput *pOut, const GlowSignal *pTarget);
   * Only valid if preceeded by a call to glow_writeTargetsPrefix.
   * @param pOut pointer to the output to be used for in-memory framing.
   */
-LIBRARY_API void glow_writeTargetsSuffix(GlowOutput *pOut);
+LIBEMBER_API void glow_writeTargetsSuffix(GlowOutput *pOut);
 
 /**
   * Writes the prefix for the "sources" sequence of a QualifiedMatrix.
@@ -256,7 +251,7 @@ LIBRARY_API void glow_writeTargetsSuffix(GlowOutput *pOut);
   *     This is encoded in the "path" field of the QualifiedMatrix.
   * @param matrixPathLength number of node numbers at @p pPath.
   */
-LIBRARY_API void glow_writeSourcesPrefix(GlowOutput *pOut,
+LIBEMBER_API void glow_writeSourcesPrefix(GlowOutput *pOut,
                              const berint *pMatrixPath,
                              int matrixPathLength);
 
@@ -266,7 +261,7 @@ LIBRARY_API void glow_writeSourcesPrefix(GlowOutput *pOut,
   * @param pOut pointer to the output to be used for in-memory framing.
   * @param pConnection pointer to the source to write.
   */
-LIBRARY_API void glow_writeSource(GlowOutput *pOut, const GlowSignal *pSource);
+LIBEMBER_API void glow_writeSource(GlowOutput *pOut, const GlowSignal *pSource);
 
 /**
   * Writes the suffix for the "sources" sequence of a QualifiedMatrix.
@@ -274,7 +269,7 @@ LIBRARY_API void glow_writeSource(GlowOutput *pOut, const GlowSignal *pSource);
   * Only valid if preceeded by a call to glow_writeSourcesPrefix.
   * @param pOut pointer to the output to be used for in-memory framing.
   */
-LIBRARY_API void glow_writeSourcesSuffix(GlowOutput *pOut);
+LIBEMBER_API void glow_writeSourcesSuffix(GlowOutput *pOut);
 
 /**
   * Writes the prefix for the "connections" sequence of a QualifiedMatrix.
@@ -285,7 +280,7 @@ LIBRARY_API void glow_writeSourcesSuffix(GlowOutput *pOut);
   *     This is encoded in the "path" field of the QualifiedMatrix.
   * @param matrixPathLength number of node numbers at @p pPath.
   */
-LIBRARY_API void glow_writeConnectionsPrefix(GlowOutput *pOut,
+LIBEMBER_API void glow_writeConnectionsPrefix(GlowOutput *pOut,
                                  const berint *pMatrixPath,
                                  int matrixPathLength);
 
@@ -295,7 +290,7 @@ LIBRARY_API void glow_writeConnectionsPrefix(GlowOutput *pOut,
   * @param pOut pointer to the output to be used for in-memory framing.
   * @param pConnection pointer to the connection to write.
   */
-LIBRARY_API void glow_writeConnection(GlowOutput *pOut, const GlowConnection *pConnection);
+LIBEMBER_API void glow_writeConnection(GlowOutput *pOut, const GlowConnection *pConnection);
 
 /**
   * Writes the suffix for the "connections" sequence of a QualifiedMatrix.
@@ -303,7 +298,7 @@ LIBRARY_API void glow_writeConnection(GlowOutput *pOut, const GlowConnection *pC
   * Only valid if preceeded by a call to glow_writeConnectionsPrefix.
   * @param pOut pointer to the output to be used for in-memory framing.
   */
-LIBRARY_API void glow_writeConnectionsSuffix(GlowOutput *pOut);
+LIBEMBER_API void glow_writeConnectionsSuffix(GlowOutput *pOut);
 
 /**
   * Writes a Function to the passed GlowOutput, encoding @p pFunction
@@ -319,7 +314,7 @@ LIBRARY_API void glow_writeConnectionsSuffix(GlowOutput *pOut);
   *     This is encoded in the "path" field of the QualifiedFunction.
   * @param pathLength number of node numbers at @p pPath.
   */
-LIBRARY_API void glow_writeQualifiedFunction(GlowOutput *pOut,
+LIBEMBER_API void glow_writeQualifiedFunction(GlowOutput *pOut,
                                  const GlowFunction *pFunction,
                                  GlowFieldFlags fields,
                                  const berint *pPath,
@@ -332,6 +327,6 @@ LIBRARY_API void glow_writeQualifiedFunction(GlowOutput *pOut,
   * @param pInvocationResult pointer to the InvocationResult to write.
   * @return the number of bytes written to the output.
   */
-LIBRARY_API unsigned int glow_writeInvocationResultPackage(GlowOutput *pOut, const GlowInvocationResult *pRoot);
+LIBEMBER_API unsigned int glow_writeInvocationResultPackage(GlowOutput *pOut, const GlowInvocationResult *pRoot);
 
 #endif//__LIBEMBER_SLIM_GLOWTX_H

--- a/libember_slim/Source/glowtx.h
+++ b/libember_slim/Source/glowtx.h
@@ -20,6 +20,12 @@
 #ifndef __LIBEMBER_SLIM_GLOWTX_H
 #define __LIBEMBER_SLIM_GLOWTX_H
 
+#ifdef LIBEMBER_DLL_EXPORTS
+#define LIBRARY_API __declspec(dllexport)
+#else
+#define LIBRARY_API
+#endif
+
 #include "glow.h"
 
 // ====================================================================
@@ -74,7 +80,7 @@ typedef struct SGlowOutput
   * @param slotId the slot id as described in the
   *     framing protocol documentation.
   */
-void glowOutput_init(GlowOutput *pThis,
+LIBRARY_API void glowOutput_init(GlowOutput *pThis,
                      byte *pMemory,
                      unsigned int size,
                      byte slotId);
@@ -87,7 +93,7 @@ void glowOutput_init(GlowOutput *pThis,
   * @param isLastPackage if true, the EmberFramingFlag_LastPackage flag
   *     is set in the header.
   */
-void glowOutput_beginPackage(GlowOutput *pThis, bool isLastPackage);
+LIBRARY_API void glowOutput_beginPackage(GlowOutput *pThis, bool isLastPackage);
 
 /**
   * Begins a new package by writing the framing header and the start tag
@@ -97,7 +103,7 @@ void glowOutput_beginPackage(GlowOutput *pThis, bool isLastPackage);
   * @param isLastPackage if true, the EmberFramingFlag_LastPackage flag
   *     is set in the header.
   */
-void glowOutput_beginStreamPackage(GlowOutput *pThis, bool isLastPackage);
+LIBRARY_API void glowOutput_beginStreamPackage(GlowOutput *pThis, bool isLastPackage);
 
 /**
   * Finishes the framed package. After this function
@@ -109,7 +115,7 @@ void glowOutput_beginStreamPackage(GlowOutput *pThis, bool isLastPackage);
   * @note you need to call this function when you have
   *     written a complete glow tree to @p pThis.
   */
-unsigned int glowOutput_finishPackage(GlowOutput *pThis);
+LIBRARY_API unsigned int glowOutput_finishPackage(GlowOutput *pThis);
 
 
 // ====================================================================
@@ -131,7 +137,7 @@ unsigned int glowOutput_finishPackage(GlowOutput *pThis);
   *     number. May be NULL only if pathLength is 0.
   * @param pathLength number of node numbers at @p pPath.
   */
-void glow_writeQualifiedNode(GlowOutput *pOut,
+LIBRARY_API void glow_writeQualifiedNode(GlowOutput *pOut,
                              const GlowNode *pNode,
                              GlowFieldFlags fields,
                              const berint *pPath,
@@ -150,7 +156,7 @@ void glow_writeQualifiedNode(GlowOutput *pOut,
   *     number. May be NULL only if pathLength is 0.
   * @param pathLength number of node numbers at @p pPath.
   */
-void glow_writeQualifiedParameter(GlowOutput *pOut,
+LIBRARY_API void glow_writeQualifiedParameter(GlowOutput *pOut,
                                   const GlowParameter *pParameter,
                                   GlowFieldFlags fields,
                                   const berint *pPath,
@@ -179,7 +185,7 @@ void glow_writeQualifiedParameter(GlowOutput *pOut,
   *     - parentType = GlowElementType_Matrix:
   *       command is nested in a QualifiedMatrix
   */
-void glow_writeQualifiedCommand(GlowOutput *pOut,
+LIBRARY_API void glow_writeQualifiedCommand(GlowOutput *pOut,
                                 const GlowCommand *pCommand,
                                 const berint *pPath,
                                 int pathLength,
@@ -190,7 +196,7 @@ void glow_writeQualifiedCommand(GlowOutput *pOut,
   * @param pOut pointer to the output to be used for in-memory framing.
   * @param pEntry pointer to GlowStreamEntry object to write.
   */
-void glow_writeStreamEntry(GlowOutput *pOut, const GlowStreamEntry *pEntry);
+LIBRARY_API void glow_writeStreamEntry(GlowOutput *pOut, const GlowStreamEntry *pEntry);
 
 /**
   * Writes a Matrix to the passed GlowOutput, encoding @p pMatrix
@@ -208,7 +214,7 @@ void glow_writeStreamEntry(GlowOutput *pOut, const GlowStreamEntry *pEntry);
   *     This is encoded in the "path" field of the QualifiedMatrix.
   * @param pathLength number of node numbers at @p pPath.
   */
-void glow_writeQualifiedMatrix(GlowOutput *pOut,
+LIBRARY_API void glow_writeQualifiedMatrix(GlowOutput *pOut,
                                const GlowMatrix *pMatrix,
                                GlowFieldFlags fields,
                                const berint *pPath,
@@ -223,7 +229,7 @@ void glow_writeQualifiedMatrix(GlowOutput *pOut,
   *     This is encoded in the "path" field of the QualifiedMatrix.
   * @param matrixPathLength number of node numbers at @p pPath.
   */
-void glow_writeTargetsPrefix(GlowOutput *pOut,
+LIBRARY_API void glow_writeTargetsPrefix(GlowOutput *pOut,
                              const berint *pMatrixPath,
                              int matrixPathLength);
 
@@ -233,7 +239,7 @@ void glow_writeTargetsPrefix(GlowOutput *pOut,
   * @param pOut pointer to the output to be used for in-memory framing.
   * @param pConnection pointer to the target to write.
   */
-void glow_writeTarget(GlowOutput *pOut, const GlowSignal *pTarget);
+LIBRARY_API void glow_writeTarget(GlowOutput *pOut, const GlowSignal *pTarget);
 
 /**
   * Writes the suffix for the "targets" sequence of a QualifiedMatrix.
@@ -241,7 +247,7 @@ void glow_writeTarget(GlowOutput *pOut, const GlowSignal *pTarget);
   * Only valid if preceeded by a call to glow_writeTargetsPrefix.
   * @param pOut pointer to the output to be used for in-memory framing.
   */
-void glow_writeTargetsSuffix(GlowOutput *pOut);
+LIBRARY_API void glow_writeTargetsSuffix(GlowOutput *pOut);
 
 /**
   * Writes the prefix for the "sources" sequence of a QualifiedMatrix.
@@ -252,7 +258,7 @@ void glow_writeTargetsSuffix(GlowOutput *pOut);
   *     This is encoded in the "path" field of the QualifiedMatrix.
   * @param matrixPathLength number of node numbers at @p pPath.
   */
-void glow_writeSourcesPrefix(GlowOutput *pOut,
+LIBRARY_API void glow_writeSourcesPrefix(GlowOutput *pOut,
                              const berint *pMatrixPath,
                              int matrixPathLength);
 
@@ -262,7 +268,7 @@ void glow_writeSourcesPrefix(GlowOutput *pOut,
   * @param pOut pointer to the output to be used for in-memory framing.
   * @param pConnection pointer to the source to write.
   */
-void glow_writeSource(GlowOutput *pOut, const GlowSignal *pSource);
+LIBRARY_API void glow_writeSource(GlowOutput *pOut, const GlowSignal *pSource);
 
 /**
   * Writes the suffix for the "sources" sequence of a QualifiedMatrix.
@@ -270,7 +276,7 @@ void glow_writeSource(GlowOutput *pOut, const GlowSignal *pSource);
   * Only valid if preceeded by a call to glow_writeSourcesPrefix.
   * @param pOut pointer to the output to be used for in-memory framing.
   */
-void glow_writeSourcesSuffix(GlowOutput *pOut);
+LIBRARY_API void glow_writeSourcesSuffix(GlowOutput *pOut);
 
 /**
   * Writes the prefix for the "connections" sequence of a QualifiedMatrix.
@@ -281,7 +287,7 @@ void glow_writeSourcesSuffix(GlowOutput *pOut);
   *     This is encoded in the "path" field of the QualifiedMatrix.
   * @param matrixPathLength number of node numbers at @p pPath.
   */
-void glow_writeConnectionsPrefix(GlowOutput *pOut,
+LIBRARY_API void glow_writeConnectionsPrefix(GlowOutput *pOut,
                                  const berint *pMatrixPath,
                                  int matrixPathLength);
 
@@ -291,7 +297,7 @@ void glow_writeConnectionsPrefix(GlowOutput *pOut,
   * @param pOut pointer to the output to be used for in-memory framing.
   * @param pConnection pointer to the connection to write.
   */
-void glow_writeConnection(GlowOutput *pOut, const GlowConnection *pConnection);
+LIBRARY_API void glow_writeConnection(GlowOutput *pOut, const GlowConnection *pConnection);
 
 /**
   * Writes the suffix for the "connections" sequence of a QualifiedMatrix.
@@ -299,7 +305,7 @@ void glow_writeConnection(GlowOutput *pOut, const GlowConnection *pConnection);
   * Only valid if preceeded by a call to glow_writeConnectionsPrefix.
   * @param pOut pointer to the output to be used for in-memory framing.
   */
-void glow_writeConnectionsSuffix(GlowOutput *pOut);
+LIBRARY_API void glow_writeConnectionsSuffix(GlowOutput *pOut);
 
 /**
   * Writes a Function to the passed GlowOutput, encoding @p pFunction
@@ -315,7 +321,7 @@ void glow_writeConnectionsSuffix(GlowOutput *pOut);
   *     This is encoded in the "path" field of the QualifiedFunction.
   * @param pathLength number of node numbers at @p pPath.
   */
-void glow_writeQualifiedFunction(GlowOutput *pOut,
+LIBRARY_API void glow_writeQualifiedFunction(GlowOutput *pOut,
                                  const GlowFunction *pFunction,
                                  GlowFieldFlags fields,
                                  const berint *pPath,
@@ -328,6 +334,6 @@ void glow_writeQualifiedFunction(GlowOutput *pOut,
   * @param pInvocationResult pointer to the InvocationResult to write.
   * @return the number of bytes written to the output.
   */
-unsigned int glow_writeInvocationResultPackage(GlowOutput *pOut, const GlowInvocationResult *pRoot);
+LIBRARY_API unsigned int glow_writeInvocationResultPackage(GlowOutput *pOut, const GlowInvocationResult *pRoot);
 
 #endif//__LIBEMBER_SLIM_GLOWTX_H

--- a/libember_slim/Source/glowtx.h
+++ b/libember_slim/Source/glowtx.h
@@ -55,12 +55,10 @@ typedef struct SGlowOutput
      */
    int packageCount;
 
-#ifdef _DEBUG
    /**
      * private field
      */
    int positionHint;
-#endif
 } GlowOutput;
 
 #ifdef _DEBUG


### PR DESCRIPTION
This adds the required export declarations to build and use libember_slim as a shared library (DLL) from a third-party application. It also fixes some bugs that were discovered during testing. In particular, a possible runtime error during CRC generation is avoided, and the struct sizes are made the same for debug and release builds, so the hosting application will work with either library.