### PR TITLE
Added robustness check - if length is zero, ReadBytes() returns without…

### DIFF
--- a/EmberLib.net/EmberLib.Framing/FramingReader.cs
+++ b/EmberLib.net/EmberLib.Framing/FramingReader.cs
@@ -190,6 +190,7 @@ namespace EmberLib.Framing
       /// <param name="length">Number of bytes in <paramref name="bytes"/> to decode.</param>
       public void ReadBytes(byte[] bytes, int offset, int length)
       {
+         if (length == 0) return;
          length += offset;
 
          if(bytes == null)

--- a/EmberLib.net/EmberLib/AsyncEmberReader.cs
+++ b/EmberLib.net/EmberLib/AsyncEmberReader.cs
@@ -116,6 +116,7 @@ namespace EmberLib
       /// <param name="length">The number of bytes in <paramref name="bytes"/> to feed.</param>
       public void ReadBytes(byte[] bytes, int offset, int length)
       {
+         if (length == 0) return;
          length += offset;
 
          if(bytes == null)


### PR DESCRIPTION
… trying to read anything. This prevents index out of range exceptions to be thrown.

When connecting using lawo/ember-plus-sharp to a provider created with lawo/ember-plus/EmberLib.net, the provider is sometimes asked to read zero bytes from the stream. This breaks the provider. Adding the robustness checks of this pull request will avoid that and make the two libraries more compatible.