### PR TITLE
libember_slim: fields == GlowFieldFlag_All does not always work

### DIFF
--- a/libember_slim/Source/glow.h
+++ b/libember_slim/Source/glow.h
@@ -365,8 +365,8 @@ typedef enum EGlowFieldFlags
    GlowFieldFlag_TemplateReference  = 0x00080000,
    GlowFieldFlag_Connections        = 0x00000005,
 
-   GlowFieldFlag_All                = 0xFFFFFFFF,
-   GlowFieldFlag_Sparse             = -2
+   GlowFieldFlag_All                = (int)0xffffffff,
+   GlowFieldFlag_Sparse             = (int)0xfffffffe
 } GlowFieldFlags;
 
 


### PR DESCRIPTION
Enumeration GlowFieldFlags had member GlowFieldFlag_All defined to be 0xffffffff. For some variants of gcc, this will be expanded to 64bit in order to represent this 32bit number, since enumeration defaults to signed integer.

This becomes a problem when incomming signed 32bit integer flags, are typecasted, causing sign extension (value will stored is then 0xffffffffffffffff), so parsers that checks if packet.fields == GlowFieldFlag_All fails, since 0xffffffffff != 0xffffffffffffffff.

Easiest fix for now is this patch for now is this patch.

Best permanent fix will probably to define GlowFieldFlags as a uint32_t, and the different flags as #define, to ensure bitsize and avoid sign-extensions. Please enter the commit message for your changes. Lines starting