### PR TITLE
libember: Conditionally use std::unique_ptr instead of std::auto_ptr if using C++11 or newer

### DIFF
--- a/libember/Headers/ember/dom/Container.hpp
+++ b/libember/Headers/ember/dom/Container.hpp
@@ -145,6 +145,13 @@ namespace libember { namespace dom
             explicit Container(ber::Tag tag);
 
             /**
+             * Default copy constructor specified to disable compiler warning.
+             * As of C++11, implicit generation of copy constructor is declared
+             * as deprecated.
+             */
+            explicit Container(Container const& other);
+
+            /**
              * Helper that ensures that the parent setting of the (presumed) child
              * node is set to this container.
              * This method allows derived classes, to add child nodes to

--- a/libember/Headers/ember/dom/impl/Container.ipp
+++ b/libember/Headers/ember/dom/impl/Container.ipp
@@ -20,6 +20,11 @@ namespace libember { namespace dom
     {}
 
     LIBEMBER_INLINE
+    Container::Container(Container const& other)
+        : Node(other)
+    {}
+
+    LIBEMBER_INLINE
     Container::iterator Container::insert(iterator const& where, Node* child)
     {
         if (child->parent() != 0)

--- a/libember/Headers/ember/dom/impl/DomReader.ipp
+++ b/libember/Headers/ember/dom/impl/DomReader.ipp
@@ -38,7 +38,11 @@ namespace libember { namespace dom
         m_input = &input;
         m_bytesAvailable = input.size();
 
+#if __cplusplus >= 201103L
+        std::unique_ptr<Node> root;
+#else
         std::auto_ptr<Node> root;
+#endif
         if (read())
         {
             root.reset(decodeNode(factory));
@@ -60,7 +64,11 @@ namespace libember { namespace dom
     {
         while (reader.read())
         {
+#if __cplusplus >= 201103L
+            std::unique_ptr<Node> node(reader.decodeNode(factory));
+#else
             std::auto_ptr<Node> node(reader.decodeNode(factory));
+#endif
             if (node.get() != 0)
             {
                 if (reader.isContainer())


### PR DESCRIPTION
Fixes issue #113 