### PR TITLE
explicitly specifying c17 in libember_slim compiler args

### DIFF
--- a/libember_slim/cmake/modules/EnableWarnings.cmake
+++ b/libember_slim/cmake/modules/EnableWarnings.cmake
@@ -3,7 +3,7 @@ if (NOT ENABLE_WARNINGS_INCLUDED)
 
     function(enable_warnings_on_target target)
         if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU")
-            target_compile_options(${target} PRIVATE -Wall -Wextra -Wunreachable-code -Wpedantic -Wno-long-long)
+            target_compile_options(${target} PRIVATE -Wall -Wextra -Wunreachable-code -Wpedantic -Wno-long-long -std=c17)
         endif()
 
         if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )

--- a/premake4.lua
+++ b/premake4.lua
@@ -144,6 +144,9 @@ solution "EmberPlus SDK"
         configuration { "not windows" }
             targetname  "ember_slim"
             
+        configuration { "gmake or not windows" }
+            buildoptions { "-std=c17" }
+            
         -- Common settings for all static library configurations of this project
         configuration { "*Static" }
             kind      "StaticLib"


### PR DESCRIPTION
With recent gcc/cmake versions that compile against c23 the build fails due to 'bool' now being a built in type.

This fixes #124